### PR TITLE
More accessibility checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
   - mysql -e "GRANT ALL PRIVILEGES on incidents_test.* TO 'travis';"
   - cp config/database.travis.yml config/database.yml
 script:
-  - bundle exec rails test:system
+  - bundle exec rails test test/system -f
   - bundle exec codeclimate-test-reporter
 notifications:
   email: false

--- a/app/assets/stylesheets/incidents.scss
+++ b/app/assets/stylesheets/incidents.scss
@@ -71,3 +71,8 @@ table.history>tbody>tr{
     }
   }
 }
+
+.high-contrast-options option{
+  color: black;
+  background: white;
+}

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -62,6 +62,10 @@ body{
     background: $main-panel-background;
     margin: 1em;
 
+    a:hover{
+      background-color: inherit;
+    }
+
     h1,h2{
       text-align: center;
       margin-bottom: 1em;
@@ -71,7 +75,7 @@ body{
       @include default-borders(1px);
 
       &.delete{
-        background: #cdacac;
+        background: #e4d2d2;
       }
     }
 

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -66,6 +66,10 @@ body{
       background-color: inherit;
     }
 
+    .field_with_errors{
+      background: #ff9999;
+    }
+
     h1,h2{
       text-align: center;
       margin-bottom: 1em;

--- a/app/views/incidents/_form.html.haml
+++ b/app/views/incidents/_form.html.haml
@@ -19,7 +19,7 @@
       .field
         = form.label :bus
         = form.text_field :bus, id: :incident_bus
-      .field
+      .field.high-contrast-options
         = form.label :occurred_at
         - a11y_datetime_labels('incident_occurred_at').each do |label|
           = label

--- a/app/views/users/index.haml
+++ b/app/views/users/index.haml
@@ -1,7 +1,7 @@
 - if @inactive
-  %h1 Manage Inactive Drivers
+  %h1 Inactive Drivers
 - else 
-  %h1 Manage Active Drivers
+  %h1 Active Drivers
 
 .center
   - if params[:inactive]

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 98.92
+    "covered_percent": 41.54
   }
 }

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 41.54
+    "covered_percent": 98.92
   }
 }

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 require 'capybara/accessible'
 require 'selenium-webdriver'
 
+# rubocop:disable Layout/CommentIndentation
 Capybara::Accessible::Auditor.severe_rules = [
   'AX_HTML_01',  # The web page must have the content's human language must be
                  # indicated in the markup
@@ -15,6 +16,7 @@ Capybara::Accessible::Auditor.severe_rules = [
   'AX_COLOR_01', # Text elements should have a reasonable contrast ratio
   'AX_TABLE_01', # Tables must have appropriate headers
 ]
+# rubocop:enable Layout/CommentIndentation
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :accessible_selenium, using: :firefox, screen_size: [1024, 768]

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -4,6 +4,18 @@ require 'test_helper'
 require 'capybara/accessible'
 require 'selenium-webdriver'
 
+Capybara::Accessible::Auditor.severe_rules = [
+  'AX_HTML_01',  # The web page must have the content's human language must be
+                 # indicated in the markup
+  'AX_HTML_02',  # An element's ID must be unique in the DOM
+  'AX_TEXT_01',  # Controls and media elements should have labels
+  'AX_TEXT_02',  # Images should have an alt attribute, unless they have an ARIA
+                 # role of 'presentation'
+  'AX_FOCUS_03', # Avoid positive integer values for tabindex
+  'AX_COLOR_01', # Text elements should have a reasonable contrast ratio
+  'AX_TABLE_01', # Tables must have appropriate headers
+]
+
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :accessible_selenium, using: :firefox, screen_size: [1024, 768]
 

--- a/test/system/deactivating_employees_test.rb
+++ b/test/system/deactivating_employees_test.rb
@@ -44,7 +44,7 @@ class DeactivatingEmployeesTest < ApplicationSystemTestCase
 
     assert_selector '.info p.notice',
                     text: 'Driver was reactivated successfully.'
-    assert_selector 'h1', text: 'Manage Active Drivers'
+    assert_selector 'h1', text: 'Active Drivers'
 
     assert_text driver.name
   end

--- a/test/system/deleting_user_test.rb
+++ b/test/system/deleting_user_test.rb
@@ -20,7 +20,7 @@ class DeletingUserTest < ApplicationSystemTestCase
     assert_selector '.navbar button', text: 'Manage Drivers'
     click_button 'Manage Drivers'
 
-    assert_selector 'h1', text: 'Manage Active Drivers'
+    assert_selector 'h1', text: 'Active Drivers'
   end
 
   test 'staff members can delete users' do

--- a/test/system/managing_users_test.rb
+++ b/test/system/managing_users_test.rb
@@ -8,14 +8,14 @@ class ManagingUsersTest < ApplicationSystemTestCase
     when_current_user_is :staff
 
     visit users_url
-    assert_selector 'h1', text: 'Manage Active Drivers'
+    assert_selector 'h1', text: 'Active Drivers'
     assert_no_text inactive_user.name
 
     click_on 'Manage inactive drivers'
-    assert_selector 'h1', text: 'Manage Inactive Drivers'
+    assert_selector 'h1', text: 'Inactive Drivers'
     assert_text inactive_user.name
 
     click_on 'Manage active drivers'
-    assert_selector 'h1', text: 'Manage Active Drivers'
+    assert_selector 'h1', text: 'Active Drivers'
   end
 end


### PR DESCRIPTION
Even more checks will cause builds to fail if they don't pass. The only ones that I needed to fix were contrast issues, again with Rails-native stuff.

My suspicion is that some checks aren't being triggered because Capybara isn't interacting with potentially offending elements. Perhaps it might be nice to make more assertions about what kind of content should be on each page, thereby causing those checks to run on those selectors.