### PR TITLE
Drivers can't select supervisors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,11 +6,16 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :set_current_user
   before_action :check_for_incomplete_incidents
+  before_action :check_for_unclaimed_incidents
 
   private
 
   def check_for_incomplete_incidents
     @incomplete_incidents = Incident.incomplete
+  end
+
+  def check_for_unclaimed_incidents
+    @unclaimed_incidents = Incident.unclaimed
   end
 
   def deny_access

--- a/app/controllers/incidents_controller.rb
+++ b/app/controllers/incidents_controller.rb
@@ -59,7 +59,11 @@ class IncidentsController < ApplicationController
   end
 
   def new
-    @incident = Incident.new
+    if @current_user.driver?
+      @incident = Incident.create driver_incident_report_attributes: { user_id: @current_user.id }
+      redirect_to edit_incident_url(@incident)
+    else @incident = Incident.new
+    end
   end
 
   def search

--- a/app/controllers/incidents_controller.rb
+++ b/app/controllers/incidents_controller.rb
@@ -3,8 +3,16 @@
 class IncidentsController < ApplicationController
   # set_incident handles access control for member routes.
   before_action :restrict_to_staff, only: %i[destroy incomplete]
+  before_action :restrict_to_supervisors, only: :claim
   before_action :set_incident, only: %i[destroy edit show update]
   before_action :set_driver_list, only: %i[create new]
+
+  def claim
+    @incident = Incident.find(params[:id])
+    @incident.claim_for @current_user
+    redirect_to incidents_url,
+                notice: 'You have claimed this incident. Please complete the supervisor report.'
+  end
 
   def create
     @incident = Incident.new

--- a/app/controllers/incidents_controller.rb
+++ b/app/controllers/incidents_controller.rb
@@ -81,6 +81,13 @@ class IncidentsController < ApplicationController
     end
   end
 
+  def unclaimed
+    @incidents = Incident.unclaimed.order :occurred_at
+    if @incidents.blank?
+      redirect_to incidents_url, notice: 'No unclaimed incidents.'
+    end
+  end
+
   def unreviewed
     @incidents = Incident.unreviewed.order :occurred_at
     if @incidents.blank?

--- a/app/models/incident.rb
+++ b/app/models/incident.rb
@@ -50,6 +50,12 @@ class Incident < ApplicationRecord
 
   after_create :send_notifications
 
+  def claim_for(user)
+    supervisor_incident_report = create_supervisor_incident_report user: user
+    supervisor_report = create_supervisor_report
+    save!
+  end
+
   def occurred_at_readable
     [occurred_date, occurred_time].join ' - '
   end

--- a/app/models/incident.rb
+++ b/app/models/incident.rb
@@ -41,6 +41,7 @@ class Incident < ApplicationRecord
   }
   scope :incomplete, -> { where completed: false }
   scope :completed, -> { where completed: true }
+  scope :unclaimed, -> { incomplete.where supervisor_incident_report_id: nil }
 
   # It turns out that with MySQL, this *is* case-insensitive.
   scope :by_claim, ->(number) {
@@ -63,6 +64,10 @@ class Incident < ApplicationRecord
 
   def reviewed?
     staff_reviews.present?
+  end
+
+  def unclaimed?
+    !completed? && supervisor_incident_report.nil?
   end
 
   private

--- a/app/views/incidents/_table.haml
+++ b/app/views/incidents/_table.haml
@@ -10,7 +10,7 @@
         %th Bus
         %th Location
         %th Complete?
-        - if @current_user.staff?
+        - if @current_user.staff? || @current_user.supervisor?
           %th{ colspan: 4 }
         - else
           %th{ colspan: 3 }
@@ -25,6 +25,11 @@
           %td= incident.driver_incident_report.bus
           %td= incident.driver_incident_report.location
           %td= yes_no_image incident.completed?
+          - unless @current_user.driver?
+            %td
+              - if incident.unclaimed?
+                = link_to claim_incident_url(incident), method: :post do
+                  %button.btn.btn-default Claim
           - if @current_user.staff?
             %td
               = link_to incident_url(incident, format: :pdf) do

--- a/app/views/incidents/edit.html.haml
+++ b/app/views/incidents/edit.html.haml
@@ -24,7 +24,7 @@
     %h2 Supervisor Report
     = render 'supervisor_reports/form',
       report: @incident.supervisor_report
-- else
+- elsif @current_user.supervisor? || @current_user.staff?
   %h3 Assign a supervisor...
   = render 'incidents/add_supervisor', incident: @incident
 = link_to 'Show', @incident

--- a/app/views/incidents/unclaimed.haml
+++ b/app/views/incidents/unclaimed.haml
@@ -1,0 +1,3 @@
+%h1 Incidents Not Claimed by a Supervisor
+= render 'division_filters'
+= render 'table'

--- a/app/views/layouts/_navbar.haml
+++ b/app/views/layouts/_navbar.haml
@@ -16,6 +16,12 @@
             %button.btn.btn-default.navbar-btn.navbar-left
               Incomplete Incidents
               .number-icon= @incomplete_incidents.count
+      - unless @current_user.driver?
+        - if @unclaimed_incidents.any?
+          = link_to unclaimed_incidents_url do
+            %button.btn.btn-default.navbar-btn.navbar-left
+              Unclaimed Incidents
+              .number-icon= @unclaimed_incidents.count
       = link_to new_incident_url do
         %button.btn.btn-default.navbar-btn.navbar-left New Incident
       = link_to destroy_session_url, method: :delete do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
       get  :unreviewed
     end
     member do
+      post :claim
       get  :history
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     collection do
       get  :incomplete
       get  :search
+      get  :unclaimed
       get  :unreviewed
     end
     member do


### PR DESCRIPTION
Closes #53.

Removes the ability for drivers to select supervisors.

![screen shot 2017-12-08 at 12 37 17 pm](https://user-images.githubusercontent.com/3988134/33779445-f1179e1e-dc1a-11e7-9d7c-57c732f1678a.png)


Adds the ability for supervisors to 'claim' incidents as their own.

![screen shot 2017-12-08 at 12 46 21 pm](https://user-images.githubusercontent.com/3988134/33779450-f5fa9c4c-dc1a-11e7-956e-550d5f062605.png)
![screen shot 2017-12-08 at 12 46 25 pm](https://user-images.githubusercontent.com/3988134/33779451-f6162606-dc1a-11e7-9818-897d871124be.png)

![screen shot 2017-12-08 at 1 22 05 pm](https://user-images.githubusercontent.com/3988134/33779461-03ba4e04-dc1b-11e7-9a73-6d44bb15c363.png)
