### PR TITLE
Restrict staff to their division(s)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,11 +11,11 @@ class ApplicationController < ActionController::Base
   private
 
   def check_for_incomplete_incidents
-    @incomplete_incidents = Incident.incomplete
+    @incomplete_incidents = Incident.in_divisions(@current_user.divisions).incomplete
   end
 
   def check_for_unclaimed_incidents
-    @unclaimed_incidents = Incident.unclaimed
+    @unclaimed_incidents = Incident.in_divisions(@current_user.divisions).unclaimed
   end
 
   def deny_access

--- a/app/controllers/incidents_controller.rb
+++ b/app/controllers/incidents_controller.rb
@@ -5,7 +5,7 @@ class IncidentsController < ApplicationController
   before_action :restrict_to_staff, only: %i[destroy incomplete]
   before_action :restrict_to_supervisors, only: :claim
   before_action :set_incident, only: %i[destroy edit show update]
-  before_action :set_driver_list, only: %i[create new]
+  before_action :set_user_lists, only: %i[create new]
 
   def claim
     @incident = Incident.find(params[:id])
@@ -166,10 +166,9 @@ class IncidentsController < ApplicationController
   end
   # rubocop:enable Style/IfUnlessModifier
 
-  def set_driver_list
-    @drivers = if @current_user.driver? then [@current_user]
-               else User.active.drivers.name_order
-               end
+  def set_user_lists
+    @drivers = User.active.drivers.in_divisions(@current_user.divisions).name_order
+    @supervisors = User.active.supervisors.in_divisions(@current_user.divisions).name_order
   end
 
   def record_print_event

--- a/app/controllers/incidents_controller.rb
+++ b/app/controllers/incidents_controller.rb
@@ -50,7 +50,7 @@ class IncidentsController < ApplicationController
   end
 
   def incomplete
-    @incidents = Incident.incomplete.occurred_order
+    @incidents = Incident.in_divisions(@current_user.divisions).incomplete.occurred_order
     if @incidents.blank?
       redirect_to incidents_url, notice: 'No incomplete incidents.'
     end
@@ -60,6 +60,7 @@ class IncidentsController < ApplicationController
     if @current_user.staff?
       parse_dates
       @incidents = Incident.between(@start_date, @end_date)
+                           .in_divisions(@current_user.divisions)
                            .includes(:driver, :supervisor, :staff_reviews)
                            .occurred_order
       render :by_date and return
@@ -80,7 +81,7 @@ class IncidentsController < ApplicationController
   end
 
   def search
-    @incidents = Incident.by_claim(params.require :claim_number)
+    @incidents = Incident.in_divisions(@current_user.divisions).by_claim(params.require :claim_number)
                          .includes(:driver, :supervisor, :staff_reviews)
                          .occurred_order
     render :by_date
@@ -95,14 +96,14 @@ class IncidentsController < ApplicationController
   end
 
   def unclaimed
-    @incidents = Incident.unclaimed.occurred_order
+    @incidents = Incident.in_divisions(@current_user.divisions).unclaimed.occurred_order
     if @incidents.blank?
       redirect_to incidents_url, notice: 'No unclaimed incidents.'
     end
   end
 
   def unreviewed
-    @incidents = Incident.unreviewed.occurred_order
+    @incidents = Incident.in_divisions(@current_user.divisions).unreviewed.occurred_order
     if @incidents.blank?
       redirect_to incidents_url, notice: 'No unreviewed incidents.'
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class SessionsController < ApplicationController
-  skip_before_action :set_current_user
+  skip_before_action :set_current_user,
+                     :check_for_incomplete_incidents,
+                     :check_for_unclaimed_incidents
 
   def destroy
     session.clear

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -100,7 +100,7 @@ class UsersController < ApplicationController
   def user_params
     attrs = params.require(:user).permit :first_name, :last_name, :badge_number,
                                          :supervisor, :staff, :hastus_id,
-                                         :division, :email
+                                         :email, division_ids: []
     if attrs[:password].blank?
       attrs.delete :password
       attrs.delete :password_confirmation

--- a/app/models/division.rb
+++ b/app/models/division.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Division < ApplicationRecord
+  validates :name, presence: true, uniqueness: true
+  has_many :users
+end

--- a/app/models/division.rb
+++ b/app/models/division.rb
@@ -2,5 +2,6 @@
 
 class Division < ApplicationRecord
   validates :name, presence: true, uniqueness: true
-  has_many :users
+  has_many :divisions_users
+  has_many :users, through: :divisions_users
 end

--- a/app/models/divisions_user.rb
+++ b/app/models/divisions_user.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class DivisionsUser < ApplicationRecord
+  belongs_to :user
+  belongs_to :division
+end

--- a/app/models/incident.rb
+++ b/app/models/incident.rb
@@ -35,6 +35,11 @@ class Incident < ApplicationRecord
       .where incident_reports: { occurred_at: start_date..end_date }
   end)
 
+  scope :in_divisions, (lambda do |divisions|
+    joins(driver: :divisions_users)
+      .where divisions_users: { division_id: divisions.pluck(:id) }
+  end)
+
   scope :occurred_order, (lambda do
     joins(:driver_incident_report).order 'incident_reports.occurred_at'
   end)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,9 +5,9 @@ class User < ApplicationRecord
 
 
   has_many :incident_reports, dependent: :restrict_with_error
-  belongs_to :division
+  has_and_belongs_to_many :divisions
 
-  validates :first_name, :last_name, :hastus_id, :division, presence: true
+  validates :first_name, :last_name, :hastus_id, :divisions, presence: true
   validates :hastus_id, uniqueness: true
   # validates :badge_number, presence: true, if: :driver?
 
@@ -19,6 +19,10 @@ class User < ApplicationRecord
   scope :with_email, -> { where.not email: nil }
 
   scope :name_order, -> { order :last_name, :first_name }
+
+  def division
+    divisions.first
+  end
 
   def driver?
     !(supervisor? || staff?)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,13 +3,12 @@
 class User < ApplicationRecord
   has_paper_trail
 
-  DIVISIONS = %w[NOHO SMECH SPFLD].freeze
 
   has_many :incident_reports, dependent: :restrict_with_error
+  belongs_to :division
 
   validates :first_name, :last_name, :hastus_id, :division, presence: true
   validates :hastus_id, uniqueness: true
-  validates :division, inclusion: { in: DIVISIONS }
   # validates :badge_number, presence: true, if: :driver?
 
   scope :active, -> { where active: true }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,9 @@ class User < ApplicationRecord
   scope :with_email, -> { where.not email: nil }
 
   scope :name_order, -> { order :last_name, :first_name }
+  scope :in_divisions, (lambda do |divisions|
+    joins(:divisions_users).where(divisions_users: { division_id: divisions.pluck(:id) })
+  end)
 
   def division
     divisions.first

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,8 @@ class User < ApplicationRecord
 
 
   has_many :incident_reports, dependent: :restrict_with_error
-  has_and_belongs_to_many :divisions
+  has_many :divisions_users
+  has_many :divisions, through: :divisions_users
 
   validates :first_name, :last_name, :hastus_id, :divisions, presence: true
   validates :hastus_id, uniqueness: true

--- a/app/views/incidents/_division_filters.haml
+++ b/app/views/incidents/_division_filters.haml
@@ -1,4 +1,4 @@
 .filters.divisions
   %button.btn.btn-primary All
-  - User::DIVISIONS.each do |division|
-    %button.btn= division
+  - @current_user.divisions.each do |division|
+    %button.btn= division.name

--- a/app/views/incidents/_table.haml
+++ b/app/views/incidents/_table.haml
@@ -18,7 +18,7 @@
           %th{ colspan: 3 }
     %tbody
       - @incidents.each do |incident|
-        %tr{data: { division: incident.division }}
+        %tr{data: { division: incident.division.name }}
           %td= incident.driver.proper_name
           %td= incident.supervisor.try :proper_name
           %td= incident.occurred_at_readable

--- a/app/views/incidents/_table.haml
+++ b/app/views/incidents/_table.haml
@@ -10,7 +10,9 @@
         %th Bus
         %th Location
         %th Complete?
-        - if @current_user.staff? || @current_user.supervisor?
+        - if @current_user.staff?
+          %th{ colspan: 5 }
+        - if @current_user.supervisor?
           %th{ colspan: 4 }
         - else
           %th{ colspan: 3 }

--- a/app/views/incidents/by_date.haml
+++ b/app/views/incidents/by_date.haml
@@ -20,6 +20,6 @@
       %button.btn.btn-primary
         Next #{@mode}
         &rarr;
-= render 'division_filters'
+= render 'division_filters' if @current_user.divisions.many?
 = render 'claim_search'
 = render 'table'

--- a/app/views/incidents/new.html.haml
+++ b/app/views/incidents/new.html.haml
@@ -19,7 +19,7 @@
     .field
       = supervisor_form.label :user_id, 'Supervisor'
       = supervisor_form.select :user_id,
-        options_from_collection_for_select(User.active.supervisors.name_order, :id, :proper_name, @current_user.id),
+        options_from_collection_for_select(@supervisors, :id, :proper_name, @current_user.id),
         { include_blank: true }, id: :report_supervisor_id
   .actions= form.submit 'Create Incident Report'
 = link_to 'Back', incidents_url

--- a/app/views/users/_form.haml
+++ b/app/views/users/_form.haml
@@ -18,8 +18,10 @@
       %td= f.label :hastus_id
       %td= f.text_field :hastus_id
     %tr
-      %td= f.label :division
-      %td= f.select :division, options_for_select(User::DIVISIONS)
+      %td= f.label :division_ids
+      %td= f.select :division_ids,
+        options_from_collection_for_select(Division.order(:name), :id, :name, user.divisions.pluck(:id)),
+        { }, multiple: true
     %tr
       %td= f.label :supervisor
       %td= f.check_box :supervisor

--- a/app/views/users/index.haml
+++ b/app/views/users/index.haml
@@ -11,7 +11,7 @@
 
 .filters.groups
   %button.btn.btn-primary All
-  %button.btn Users
+  %button.btn Drivers
   %button.btn Supervisors
   %button.btn Staff
 
@@ -20,7 +20,7 @@
     %tr
       %th Name
       %th Hastus ID
-      %th Division
+      %th Division(s)
       %th Supervisor?
       %th Staff?
       %th{ colspan: 4 }
@@ -29,7 +29,7 @@
       %tr{ data: { group: user.group } }
         %td= user.proper_name
         %td= user.hastus_id
-        %td= user.division
+        %td= user.divisions.pluck(:name).join ', '
         %td= yes_no_image user.supervisor?
         %td= yes_no_image user.staff?
         %td

--- a/db/migrate/20171214202906_create_divisions.rb
+++ b/db/migrate/20171214202906_create_divisions.rb
@@ -1,0 +1,8 @@
+class CreateDivisions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :divisions do |t|
+      t.string :name, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20171214203943_add_division_id_to_users.rb
+++ b/db/migrate/20171214203943_add_division_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddDivisionIdToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :division_id, :integer
+  end
+end

--- a/db/migrate/20171214203943_add_division_id_to_users.rb
+++ b/db/migrate/20171214203943_add_division_id_to_users.rb
@@ -1,5 +1,0 @@
-class AddDivisionIdToUsers < ActiveRecord::Migration[5.1]
-  def change
-    add_column :users, :division_id, :integer
-  end
-end

--- a/db/migrate/20171215150218_create_divisions_users.rb
+++ b/db/migrate/20171215150218_create_divisions_users.rb
@@ -1,0 +1,5 @@
+class CreateDivisionsUsers < ActiveRecord::Migration[5.1]
+  def change
+    create_join_table :divisions, :users
+  end
+end

--- a/db/migrate/20171215151312_add_uniqueness_index_to_divisions_users.rb
+++ b/db/migrate/20171215151312_add_uniqueness_index_to_divisions_users.rb
@@ -1,0 +1,5 @@
+class AddUniquenessIndexToDivisionsUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_index :divisions_users, [:division_id, :user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171214203943) do
+ActiveRecord::Schema.define(version: 20171215151312) do
 
   create_table "divisions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "divisions_users", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.bigint "division_id", null: false
+    t.bigint "user_id", null: false
+    t.index ["division_id", "user_id"], name: "index_divisions_users_on_division_id_and_user_id", unique: true
   end
 
   create_table "incident_reports", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -187,7 +193,6 @@ ActiveRecord::Schema.define(version: 20171214203943) do
     t.string "last_name"
     t.string "division"
     t.string "email"
-    t.integer "division_id"
   end
 
   create_table "versions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171213165648) do
+ActiveRecord::Schema.define(version: 20171214203943) do
+
+  create_table "divisions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "incident_reports", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "run"
@@ -181,6 +187,7 @@ ActiveRecord::Schema.define(version: 20171213165648) do
     t.string "last_name"
     t.string "division"
     t.string "email"
+    t.integer "division_id"
   end
 
   create_table "versions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,11 +9,11 @@ include FactoryBot::Syntax::Methods
 
 divisions = %w[SPFLD NOHO SMECH].map { |n| create :division, name: n }
 
-staff = Array.new(5) { create :user, :staff, :fake_name, division: divisions.sample }
+staff = Array.new(5) { create :user, :staff, :fake_name, divisions: [divisions.sample] }
 
-supervisors = Array.new(10) { create :user, :supervisor, :fake_name, division: divisions.sample }
+supervisors = Array.new(10) { create :user, :supervisor, :fake_name, divisions: [divisions.sample] }
 
-drivers = Array.new(50) { create :user, :driver, :fake_name, division: divisions.sample }
+drivers = Array.new(50) { create :user, :driver, :fake_name, divisions: [divisions.sample] }
 
 
 codes = {

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -51,7 +51,10 @@ dates.shuffle.each.with_index do |day, i|
       incident_attrs[:supervisor_incident_report] = nil
       incident_attrs[:supervisor_report] = nil
     end
-    incident = create :incident, incident_attrs
+    incident = build :incident, incident_attrs
+    # Validations don't pass for incomplete incidents. They do in real life,
+    # but they don't because we create objects in reverse order here.
+    incident.save validate: false
     if Time.zone.now < claim_date
       number = if rand(5).zero?
                  Incident.pluck(:claim_number).compact.sample

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,11 +7,14 @@ require 'timecop'
 
 include FactoryBot::Syntax::Methods
 
-staff = create :user, :staff, :fake_name
+divisions = %w[SPFLD NOHO SMECH].map { |n| create :division, name: n }
 
-supervisors = Array.new(10) { create :user, :supervisor, :fake_name }
+staff = create :user, :staff, :fake_name, division: divisions.sample
 
-drivers = Array.new(50) { create :user, :driver, :fake_name }
+supervisors = Array.new(10) { create :user, :supervisor, :fake_name, division: divisions.sample }
+
+drivers = Array.new(50) { create :user, :driver, :fake_name, division: divisions.sample }
+
 
 codes = {
   collision: create(:reason_code, description: 'Collision'),

--- a/lib/tasks/divisions.rake
+++ b/lib/tasks/divisions.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+namespace :divisions do
+  desc 'Migrate users from string divisions to the table association.'
+  task :migrate do
+    User.all.each do |u|
+      division_name = u.attributes[:division]
+      division = Division.where(name: division_name).first_or_create
+      u.update! division_id: division.id
+    end
+  end
+end

--- a/lib/tasks/divisions.rake
+++ b/lib/tasks/divisions.rake
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 namespace :divisions do
-  desc 'Migrate users from string divisions to the table association.'
-  task :migrate do
+  desc 'Migrate from string division to join table divisions'
+  task migrate: :environment do
     User.all.each do |u|
-      division_name = u.attributes[:division]
-      division = Division.where(name: division_name).first_or_create
-      u.update! division_id: division.id
+      division = Division.where(name: u.division).first_or_create
+      u.divisions << division
+      u.save!
     end
   end
 end

--- a/spec/factories/divisions.rb
+++ b/spec/factories/divisions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :division do
+    sequence(:name)
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     first_name 'User'
     sequence :last_name
     sequence :hastus_id
-    division { %w[SPFLD NOHO SMECH].sample }
+    division
     badge_number { rand(5000).to_s.rjust 4, '0' }
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     first_name 'User'
     sequence :last_name
     sequence :hastus_id
-    division
+    division { %w[SPFLD NOHO SMECH].sample }
     badge_number { rand(5000).to_s.rjust 4, '0' }
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -16,11 +16,13 @@ FactoryBot.define do
 
   trait :supervisor do
     supervisor true
+    staff false
     badge_number nil
   end
 
   trait :staff do
     staff true
+    supervisor { rand(2).zero? }
     badge_number nil
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
 
   trait :staff do
     staff true
-    supervisor { rand(2).zero? }
+    supervisor { [true, false].sample }
     badge_number nil
   end
 


### PR DESCRIPTION
Closes #67.

Drivers:
  + No changes.

Supervisors:
  + Can only select drivers in their division(s) when creating a new incident.

Staff:
  + Can only select drivers in their division(s) when creating a new incident.
  + Can only see incidents in their division(s).

If needed, staff can edit themselves to be in multiple divisions. This isn't really about access control (for staff), more about ease of use.

Editing a user's divisions:
<img width="639" alt="screen shot 2017-12-15 at 10 59 03 am" src="https://user-images.githubusercontent.com/3988134/34050973-d65c5ab8-e18a-11e7-95c8-bdc8f607cd56.png">

A user in multiple divisions:
<img width="992" alt="screen shot 2017-12-15 at 10 58 57 am" src="https://user-images.githubusercontent.com/3988134/34050979-de40365a-e18a-11e7-92e1-fab183e3947d.png">

A supervisor selecting drivers from only one division:
<img width="1020" alt="screen shot 2017-12-15 at 11 24 45 am" src="https://user-images.githubusercontent.com/3988134/34050989-e595b88a-e18a-11e7-9952-e675976e5391.png">
