### PR TITLE
Supplementary reason codes

### DIFF
--- a/app/controllers/incidents_controller.rb
+++ b/app/controllers/incidents_controller.rb
@@ -64,6 +64,8 @@ class IncidentsController < ApplicationController
 
   def edit
     deny_access and return if !current_user.staff? && @incident.reviewed?
+    @reason_codes = ReasonCode.order(:identifier)
+    @supplementary_reason_codes = SupplementaryReasonCode.order(:identifier)
     if current_user.driver?
       # It's the only thing they can edit anyway.
       redirect_to edit_incident_report_url(@incident.driver_incident_report)
@@ -131,6 +133,8 @@ class IncidentsController < ApplicationController
   end
 
   def update
+    @reason_codes = ReasonCode.order(:identifier)
+    @supplementary_reason_codes = SupplementaryReasonCode.order(:identifier)
     @incident.assign_attributes incident_params
     respond_to do |format|
       if @incident.save

--- a/app/models/reason_code.rb
+++ b/app/models/reason_code.rb
@@ -2,7 +2,8 @@
 
 class ReasonCode < ApplicationRecord
   has_many :incidents
-  validates :identifier, :description, presence: true, uniqueness: true
+  validates :identifier, :description, presence: true
+  validates :identifier, uniqueness: true # description isn't unique, apparently
 
   def full_label
     [identifier, description].join ': '

--- a/app/models/supplementary_reason_code.rb
+++ b/app/models/supplementary_reason_code.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class SupplementaryReasonCode < ReasonCode
+end

--- a/app/views/incidents/_form.haml
+++ b/app/views/incidents/_form.haml
@@ -32,13 +32,13 @@
   .field
     = form.label :reason_code_id
     = form.select :reason_code_id,
-      options_from_collection_for_select(ReasonCode.order(:identifier), :id, :full_label, incident.reason_code.try(:id)),
+      options_from_collection_for_select(@reason_codes, :id, :full_label, incident.reason_code.try(:id)),
       { include_blank: true }, id: :incident_reason_code_id
   .field
-    = form.label :second_reason_code
-    = form.select :second_reason_code,
-      options_for_select(Incident::SECOND_REASON_CODES, incident.second_reason_code),
-      { include_blank: true },id: :incident_second_reason_code
+    = form.label :supplementary_reason_code_id
+    = form.select :supplementary_reason_code_id,
+      options_from_collection_for_select(@supplementary_reason_codes, :id, :full_label, incident.supplementary_reason_code.try(:id)),
+      { include_blank: true },id: :incident_supplementary_reason_code_id
   .field
     = form.label :preventable
     = form.check_box :preventable, id: :incident_preventable

--- a/app/views/incidents/_incident.xml.haml
+++ b/app/views/incidents/_incident.xml.haml
@@ -24,8 +24,8 @@
     %ai_point_of_impact= report.point_of_impact
   %ai_report_final_date= Time.zone.now.strftime '%Y-%m-%d'
   %ai_report_final_time= Time.zone.now.strftime '2000-01-01T%H:%M:00.000'
-  - if incident.second_reason_code.present?
-    %ai_second_code= incident.second_reason_code.try :first, 3
+  - if incident.supplementary_reason_code.present?
+    %ai_second_code= incident.supplementary_reason_code.try :identifier
   - if report.location.present?
     %ai_street= report.location
   %ai_type_situation= report.type_situation

--- a/app/views/incidents/show.html.haml
+++ b/app/views/incidents/show.html.haml
@@ -31,8 +31,8 @@
       %strong= human_name :incident, :reason_code
       = @incident.reason_code.full_label
     %p
-      %strong= human_name :incident, :second_reason_code
-      = @incident.second_reason_code
+      %strong= human_name :incident, :supplementary_reason_code
+      = @incident.supplementary_reason_code.full_label
     %p
       %strong= human_name :incident, :preventable
       = yes_no_image @incident.preventable

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 88.4
+    "covered_percent": 88.48
   }
 }

--- a/db/migrate/20180911000806_create_supplementary_reason_codes.rb
+++ b/db/migrate/20180911000806_create_supplementary_reason_codes.rb
@@ -1,0 +1,8 @@
+class CreateSupplementaryReasonCodes < ActiveRecord::Migration[5.1]
+  def change
+    create_table :supplementary_reason_codes do |t|
+      t.string :identifier
+      t.string :description
+    end
+  end
+end

--- a/db/migrate/20180911000832_add_supplementary_reason_code_id_to_incidents.rb
+++ b/db/migrate/20180911000832_add_supplementary_reason_code_id_to_incidents.rb
@@ -1,0 +1,5 @@
+class AddSupplementaryReasonCodeIdToIncidents < ActiveRecord::Migration[5.1]
+  def change
+    add_column :incidents, :supplementary_reason_code_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180321213642) do
+ActiveRecord::Schema.define(version: 20180911000832) do
 
   create_table "divisions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name", null: false
@@ -131,6 +131,7 @@ ActiveRecord::Schema.define(version: 20180321213642) do
     t.boolean "video_pulled"
     t.integer "claims_id"
     t.boolean "exported_to_claims"
+    t.integer "supplementary_reason_code_id"
   end
 
   create_table "injured_passengers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -196,6 +197,11 @@ ActiveRecord::Schema.define(version: 20180321213642) do
     t.boolean "driver_discounted"
     t.text "reason_threshold_not_met"
     t.text "reason_driver_discounted"
+  end
+
+  create_table "supplementary_reason_codes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "identifier"
+    t.string "description"
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/lib/tasks/supplementary_reason_codes.rake
+++ b/lib/tasks/supplementary_reason_codes.rake
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Pilfered from the incidents model
+SECOND_REASON_CODES = [
+  'a-1: Line Service - Stopped',
+  'a-2: Line Service - In Traffic, Moving',
+  'a-3: Stop - Exit',
+  'a-4: Stop - Enter',
+  'a-5: At Stop',
+  'a-6: Right Turn',
+  'a-7: Left Turn',
+  'a-8: Miscellaneous',
+  'b-1: Line Service - Stopped',
+  'b-2: Line Service - In Traffic, Moving',
+  'b-3: Stop - Exit',
+  'b-4: Stop - Enter',
+  'b-5: At Stop',
+  'b-6: Right Turn',
+  'b-7: Left Turn',
+  'b-8: Miscellaneous'
+]
+
+namespace :supplementary_reason_codes do
+  # Example invocation: rails supplementary_reason_codes:create
+  task create: :environment do
+    SECOND_REASON_CODES.each do |code|
+      identifier, description = code.split ': '
+      new_code = SupplementaryReasonCode.create! identifier: identifier,
+                                                 description: description
+      unless new_code.full_label == code
+        fail 'You dun goofed'
+      end
+    end
+  end
+
+  task migrate: :environment do
+  # Example invocation: rails supplementary_reason_codes:migrate
+    incidents = Incident.where.not second_reason_code: nil
+    incidents.each do |incident|
+      identifier = incident.second_reason_code.split(': ').first
+      code = SupplementaryReasonCode.find_by! identifier: identifier
+      incident.update supplementary_reason_code: code
+    end
+  end
+end

--- a/spec/factories/incidents.rb
+++ b/spec/factories/incidents.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
     trait :completed do
       completed true
       association :reason_code
-      second_reason_code { Incident::SECOND_REASON_CODES.sample }
+      association :supplementary_reason_code
       root_cause_analysis { FFaker::Lorem.paragraph }
       latitude { "42.#{rand(100_000).to_s.rjust 5, '0'}" }
       longitude { "-72.#{rand(100_000).to_s.rjust 5, '0'}" }

--- a/spec/factories/supplementary_reason_codes.rb
+++ b/spec/factories/supplementary_reason_codes.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :supplementary_reason_code do
+    sequence(:identifier) { |n| "D-#{n}" }
+    sequence(:description) { |n| "Scenario #{n}" }
+  end
+end

--- a/spec/system/staff/editing_incident_details_spec.rb
+++ b/spec/system/staff/editing_incident_details_spec.rb
@@ -8,6 +8,7 @@ describe 'editing incident details as staff' do
   let(:incident) { incident_in_divisions staff.divisions }
   it 'allows editing reason codes' do
     create :reason_code, identifier: 'A-1', description: 'Falling bananas'
+    create :supplementary_reason_code, identifier: 'a-8', description: 'Miscellaneous'
     visit edit_incident_url(incident)
     select 'A-1: Falling bananas', from: 'Reason code'
     click_button 'Save incident details'
@@ -17,6 +18,7 @@ describe 'editing incident details as staff' do
   end
   it 'requires reason codes, latlong, and root cause analysis for completed incidents' do
     create :reason_code, identifier: 'A-1', description: 'Falling bananas'
+    create :supplementary_reason_code, identifier: 'a-8', description: 'Miscellaneous'
     visit edit_incident_url(incident)
     check 'Completed'
     select '', from: 'Reason code'
@@ -24,12 +26,12 @@ describe 'editing incident details as staff' do
     wait_for_ajax!
     expect(page).to have_text 'This incident has 5 missing values and so cannot be marked as completed.'
     expect(page).to have_text "Reason code can't be blank"
-    expect(page).to have_text "Second reason code can't be blank"
+    expect(page).to have_text "Supplementary reason code can't be blank"
     expect(page).to have_text "Root cause analysis can't be blank"
     expect(page).to have_text "Latitude can't be blank"
     expect(page).to have_text "Longitude can't be blank"
     select 'A-1: Falling bananas', from: 'Reason code'
-    select 'a-8: Miscellaneous', from: 'Second reason code'
+    select 'a-8: Miscellaneous', from: 'Supplementary reason code'
     fill_in 'Root cause analysis', with: 'Lorem ipsum dolor sit amet.'
     fill_in 'Latitude', with: '42.105552'
     fill_in 'Longitude', with: '-72.596511'


### PR DESCRIPTION
Closes #139.

1. Merge / deploy / migrate
2. `rake supplementary_reason_codes:create && rake supplementary_reason_codes:migrate`
3. Create a migration removing the disused column.