### PR TITLE
subclasses inherit tables by default,

### DIFF
--- a/app/models/supplementary_reason_code.rb
+++ b/app/models/supplementary_reason_code.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
-class SupplementaryReasonCode < ReasonCode
+class SupplementaryReasonCode < ApplicationRecord
+  has_many :incidents
+  validates :identifier, :description, presence: true
+  validates :identifier, uniqueness: true # description isn't unique, apparently
+
+  def full_label
+    [identifier, description].join ': '
+  end
 end


### PR DESCRIPTION
so calling SupplementaryReasonCode.all would return not only all of those,
but all ReasonCode(s) also, which is not desirable. Wetness here is preferable.