### PR TITLE
Export claims XML for parallel testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ contrib/*.sql
 
 # Ignore files downloaded durung test
 /spec/downloads/*
+
+# Ignore claims XML files
+/claims_xml/*.xml


### PR DESCRIPTION
Requested by @sherson.

Allows us to parallel test the XML approach while keeping the existing integration intact.

Definitely open to suggestions on more sophisticated methods.