### PR TITLE
Added a popup menu on submit and reworded the button

### DIFF
--- a/app/views/incident_reports/_form.html.haml
+++ b/app/views/incident_reports/_form.html.haml
@@ -340,6 +340,7 @@
     = form.text_area :description, id: :incident_report_description, size: '80x8'
   .actions
     - if @current_user == @incident.driver
-      = form.submit 'Save report and preview PDF', data: {confirm: 'You are about to preview the report. Please don’t forget to print, sign, and submit it.'}
+      = form.submit 'Save report and preview PDF',
+      data: {confirm: 'You are about to preview the report. Please don’t forget to print, sign, and submit it.'}
     - else
       = form.submit 'Save report'

--- a/app/views/incident_reports/_form.html.haml
+++ b/app/views/incident_reports/_form.html.haml
@@ -340,6 +340,6 @@
     = form.text_area :description, id: :incident_report_description, size: '80x8'
   .actions
     - if @current_user == @incident.driver
-      = form.submit 'Save report and print PDF'
+      = form.submit 'Save report and preview PDF', data: {confirm: 'You are about to preview the report. Please don’t forget to print, sign, and submit it.'}
     - else
       = form.submit 'Save report'


### PR DESCRIPTION
Closes #205 
I have updated the button wording to say, 'Save Report and Preview PDF' and added an attribute that opens up a dialog box on submit.

<img width="957" alt="Screen Shot 2019-08-21 at 1 43 24 PM" src="https://user-images.githubusercontent.com/12656859/63454908-b61b9c00-c419-11e9-80a2-6435bae8f353.png">
