### PR TITLE
Seed kernel with rspec's seed

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,8 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   config.order = :random
+  Kernel.srand config.seed
+
   config.example_status_persistence_file_path =
     Rails.root.join('spec', 'examples.txt')
 


### PR DESCRIPTION
This will help with #216. Now things like `.sample` will always return the same value for the same rspec seed, which means you should be able to reproduce an occasional failure.