### PR TITLE
Found some occasional test failures, maybe fixed

### DIFF
--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 85.71
+    "covered_percent": 84.58
   }
 }

--- a/spec/support/downloads.rb
+++ b/spec/support/downloads.rb
@@ -12,4 +12,12 @@ module Downloads
   def clear_downloads
     FileUtils.rm_f(downloads)
   end
+
+  def wait_for(filename)
+    Timeout.timeout Capybara.default_max_wait_time do
+      loop do
+        break if PATH.join(filename).exist?
+      end
+    end
+  end
 end

--- a/spec/system/drivers/editing_incidents_spec.rb
+++ b/spec/system/drivers/editing_incidents_spec.rb
@@ -46,8 +46,10 @@ describe 'editing incidents as a driver' do
         fill_in 'incident_report_injured_passengers_attributes_1_nature_of_injury',
                 with: 'Slipped on many bananas'
       end
-      click_button 'Save report and preview PDF'
-      page.driver.browser.switch_to.alert.accept
+      accept_alert do
+        click_button 'Save report and preview PDF'
+      end
+      Downloads.wait_for("#{incident.id}.pdf")
 
       visit incident_url(incident)
       expect(page).to have_selector 'h2', text: 'Driver Incident Report'
@@ -61,8 +63,7 @@ describe 'editing incidents as a driver' do
   end
   context 'deleting an injured passenger' do
     it 'displays the current injured passengers' do
-      pax = create :injured_passenger, incident_report: report
-      pax2 = create :injured_passenger, incident_report: report
+      create_list :injured_passenger, 2, incident_report: report
       visit incidents_url
       expect(page).to have_selector 'table.incidents tbody tr', count: 1
       within 'tr', text: driver.proper_name do
@@ -70,8 +71,11 @@ describe 'editing incidents as a driver' do
       end
       check 'Did the incident involve a passenger?'
       click_button 'Delete injured passenger info'
-      click_button 'Save report and preview PDF'
-      page.driver.browser.switch_to.alert.accept
+
+      accept_alert do
+        click_button 'Save report and preview PDF'
+      end
+      Downloads.wait_for("#{incident.id}.pdf")
 
       visit incident_url(incident)
       expect(page).to have_selector 'h2', text: 'Driver Incident Report'


### PR DESCRIPTION
Both failures were time-based; and seemed to result from the followingsequence:

1. `visit` a page, do stuff
2. Click a button that produces a PDF
3. `visit` another page
4. Make assertions about the second page

When the tests would fail, the page contents would still be those of the first `visit`ed page. I think what was hapening was, if the second `visit` was called while the PDF download was still in progress, it just didn't do anything (?).

Anyways, these two test now reliably pass.