### PR TITLE
Removed `wait_for_ajax!`

### DIFF
--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 85.71
+    "covered_percent": 84.58
   }
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,14 +84,9 @@ def incident_in_divisions(divisions, *traits)
   create :incident, *traits, attributes.merge(driver_incident_report: report)
 end
 
-# source: https://robots.thoughtbot.com/automatically-wait-for-ajax-with-capybara
-def wait_for_ajax!
-  Timeout.timeout Capybara.default_max_wait_time do
-    loop do
-      break if page.evaluate_script('jQuery.active').zero?
-      rescue Selenium::WebDriver::Error::UnknownError
-        raise "User doesn't have correct traits to access the page being tested."
-    end
+def save_and_preview
+  accept_alert do
+    click_on 'Save report and preview PDF'
   end
 end
 

--- a/spec/system/drivers/creating_incidents_spec.rb
+++ b/spec/system/drivers/creating_incidents_spec.rb
@@ -11,10 +11,10 @@ describe 'creating incidents as a driver' do
     driver_report = Incident.last.driver_incident_report
     expect(page.current_url).to end_with edit_incident_report_path(driver_report)
   end
+
   it 'requires base fields' do
     visit new_incident_url
-    click_on 'Save report and preview PDF'
-    page.driver.browser.switch_to.alert.accept
+    save_and_preview
 
     expect(page).to have_text 'This incident report has 6 missing values and so cannot be marked as completed.'
     expect(page).to have_text "Date and time of incident can't be blank"
@@ -24,11 +24,11 @@ describe 'creating incidents as a driver' do
     expect(page).to have_text "Direction bus was travelling can't be blank"
     expect(page).to have_text "Describe the incident in detail. can't be blank"
   end
+
   it 'only requires bus, location, and town' do
     visit new_incident_url
     fill_in_base_incident_fields
-    click_on 'Save report and preview PDF'
-    page.driver.browser.switch_to.alert.accept
+    save_and_preview
 
     expect(page).not_to have_text('cannot be marked as completed')
   end

--- a/spec/system/drivers/editing_incidents_spec.rb
+++ b/spec/system/drivers/editing_incidents_spec.rb
@@ -16,10 +16,8 @@ describe 'editing incidents as a driver' do
       end
       expect(page).to have_content 'Editing Driver Account of Incident'
       incident.destroy
-      click_button 'Save report and preview PDF'
-      page.driver.browser.switch_to.alert.accept
+      save_and_preview
 
-      wait_for_ajax!
       expect(page).to have_selector 'p.notice',
                                     text: 'This incident report no longer exists.'
     end
@@ -46,8 +44,7 @@ describe 'editing incidents as a driver' do
         fill_in 'incident_report_injured_passengers_attributes_1_nature_of_injury',
                 with: 'Slipped on many bananas'
       end
-      click_button 'Save report and preview PDF'
-      page.driver.browser.switch_to.alert.accept
+      save_and_preview
 
       visit incident_url(incident)
       expect(page).to have_selector 'h2', text: 'Driver Incident Report'
@@ -70,8 +67,7 @@ describe 'editing incidents as a driver' do
       end
       check 'Did the incident involve a passenger?'
       click_button 'Delete injured passenger info'
-      click_button 'Save report and preview PDF'
-      page.driver.browser.switch_to.alert.accept
+      save_and_preview
 
       visit incident_url(incident)
       expect(page).to have_selector 'h2', text: 'Driver Incident Report'

--- a/spec/system/drivers/special_incident_fields_spec.rb
+++ b/spec/system/drivers/special_incident_fields_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 describe 'special incident fields' do
   let(:driver) { create :user, :driver }
   before(:each) { when_current_user_is driver }
+
   describe 'collision related fields' do
     context 'without collision' do
       before :each do
@@ -18,12 +19,12 @@ describe 'special incident fields' do
       it 'does not require filling in fields for collisions' do
         fill_in_base_incident_fields
         check 'Did the incident involve a collision?'
-        click_on 'Save report and preview PDF'
-        page.driver.browser.switch_to.alert.accept
+        save_and_preview
 
         expect(page).not_to have_text('cannot be marked as completed')
       end
     end
+
     context 'with collision' do
       it 'shows collision fields for collision incidents' do
         driver_report = create :incident_report,
@@ -80,12 +81,12 @@ describe 'special incident fields' do
         fill_in_base_incident_fields
         check 'Did the incident involve a collision?'
         check 'Did police respond to the incident?'
-        click_on 'Save report and preview PDF'
-        page.driver.browser.switch_to.alert.accept
+        save_and_preview
 
         expect(page).not_to have_text('cannot be marked as completed')
       end
     end
+
     context 'with police info' do
       it 'shows police fields as necessary' do
         driver_report = create :incident_report,
@@ -116,12 +117,12 @@ describe 'special incident fields' do
         fill_in_base_incident_fields
         check 'Did the incident involve a passenger?'
         expect(page).to have_text 'Passenger Incident Information'
-        click_on 'Save report and preview PDF'
-        page.driver.browser.switch_to.alert.accept
+        save_and_preview
 
         expect(page).not_to have_text('cannot be marked as completed')
       end
     end
+
     context 'with passenger incidents' do
       it 'shows passenger fields for passenger incidents' do
         driver_report = create :incident_report,
@@ -148,17 +149,18 @@ describe 'special incident fields' do
         uncheck 'Was the bus pulled completely up to the curb?'
         expect(page).to have_field 'Reason not up to curb'
       end
+
       it 'does not require filling in reason not up to curb' do
         fill_in_base_incident_fields
         check 'Did the incident involve a passenger?'
         select 'Stopped', from: 'Motion of bus'
         uncheck 'Was the bus pulled completely up to the curb?'
-        click_on 'Save report and preview PDF'
-        page.driver.browser.switch_to.alert.accept
+        save_and_preview
 
         expect(page).not_to have_text('cannot be marked as completed')
       end
     end
+
     context 'with reason not up to curb' do
       it 'shows reason not up to curb field as necessary' do
         driver_report = create :incident_report,

--- a/spec/system/staff/adding_users_spec.rb
+++ b/spec/system/staff/adding_users_spec.rb
@@ -20,7 +20,6 @@ describe 'adding users as staff' do
   it 'requires first name, last name, badge number, and divisions' do
     visit new_user_url
     click_button 'Save user'
-    wait_for_ajax!
     expect(page).to have_selector 'p',
       text: 'This user has 4 missing values and so cannot be saved:'
     expect(page).to have_text "First name can't be blank"

--- a/spec/system/staff/deleting_incidents_spec.rb
+++ b/spec/system/staff/deleting_incidents_spec.rb
@@ -10,7 +10,6 @@ describe 'deleting incidents as staff' do
     visit incidents_url
     expect(page).to have_selector 'table.incidents tbody tr', count: 1
     click_button 'Delete'
-    wait_for_ajax!
     expect(page).to have_selector 'p.notice',
       text: 'Incident was successfully deleted.'
     expect(page).not_to have_selector 'table.incidents tbody tr'

--- a/spec/system/staff/deleting_users_spec.rb
+++ b/spec/system/staff/deleting_users_spec.rb
@@ -12,7 +12,6 @@ describe 'deleting users as staff' do
       expect(page).to have_selector 'button',
         text: 'Delete', count: 1
       click_button 'Delete'
-      wait_for_ajax!
       expect(page).to have_selector 'p.notice',
         text: 'User was deleted successfully.'
       # Just the current user should be left.
@@ -30,7 +29,6 @@ describe 'deleting users as staff' do
       expect(page).to have_selector 'button',
         text: 'Delete', count: 1
       click_button 'Delete'
-      wait_for_ajax!
       expect(page).to have_selector 'p.alert',
         text: 'Cannot delete users who have incidents in their name.'
       # Should be the current user plus the undeleted user.

--- a/spec/system/staff/editing_incident_details_spec.rb
+++ b/spec/system/staff/editing_incident_details_spec.rb
@@ -12,7 +12,6 @@ describe 'editing incident details as staff' do
     visit edit_incident_url(incident)
     select 'A-1: Falling bananas', from: 'Reason code'
     click_button 'Save incident details'
-    wait_for_ajax!
     expect(page).to have_selector 'p.notice',
       text: 'Incident report was successfully saved.'
   end
@@ -23,20 +22,19 @@ describe 'editing incident details as staff' do
     check 'Completed'
     select '', from: 'Reason code'
     click_button 'Save incident details'
-    wait_for_ajax!
     expect(page).to have_text 'This incident has 5 missing values and so cannot be marked as completed.'
     expect(page).to have_text "Reason code can't be blank"
     expect(page).to have_text "Supplementary reason code can't be blank"
     expect(page).to have_text "Root cause analysis can't be blank"
     expect(page).to have_text "Latitude can't be blank"
     expect(page).to have_text "Longitude can't be blank"
+
     select 'A-1: Falling bananas', from: 'Reason code'
     select 'a-8: Miscellaneous', from: 'Supplementary reason code'
     fill_in 'Root cause analysis', with: 'Lorem ipsum dolor sit amet.'
     fill_in 'Latitude', with: '42.105552'
     fill_in 'Longitude', with: '-72.596511'
     click_button 'Save incident details'
-    wait_for_ajax!
     expect(page).to have_selector 'p.notice',
       text: 'Incident report was successfully saved.'
   end

--- a/spec/system/supervisors/claiming_incidents_spec.rb
+++ b/spec/system/supervisors/claiming_incidents_spec.rb
@@ -10,7 +10,6 @@ describe 'claiming incidents as a supervisor' do
     visit root_url
     click_button 'Unclaimed Incidents 1'
     click_button 'Claim'
-    wait_for_ajax!
     expect(page).to have_selector 'p.notice',
       text: 'You have claimed this incident. Please complete the supervisor report'
     expect(page).to have_selector 'table.incidents tbody tr', count: 1

--- a/spec/system/supervisors/editing_incidents_spec.rb
+++ b/spec/system/supervisors/editing_incidents_spec.rb
@@ -27,7 +27,6 @@ describe 'editing incidents as a supervisor' do
       expect(page).to have_content 'Editing Supervisor Account of Incident'
       incident.destroy
       click_button 'Save report'
-      wait_for_ajax!
       expect(page).to have_selector 'p.notice', text: 'This incident report no longer exists.'
     end
   end

--- a/spec/system/supervisors/editing_supervisor_reports_spec.rb
+++ b/spec/system/supervisors/editing_supervisor_reports_spec.rb
@@ -14,7 +14,6 @@ describe 'editing supervisor reports as a supervisor' do
     check 'Were pictures taken?'
     fill_in 'Number of pictures saved', with: 37
     click_button 'Save supervisor report'
-    wait_for_ajax!
     expect(page).to have_selector 'p.notice',
                                   text: 'Incident report was successfully saved.'
     expect(page).to have_text 'Number of pictures saved: 37'
@@ -28,9 +27,8 @@ describe 'editing supervisor reports as a supervisor' do
     check 'I can completely discount the operator' # But don't give a reason
 
     click_button 'Save supervisor report'
-    wait_for_ajax!
 
-    expect(page.current_path).to eq supervisor_report_path(incident.supervisor_report)
+    expect(page).to have_current_path supervisor_report_path(incident.supervisor_report)
     expect(page).to have_text 'cannot be marked as complete'
   end
   context 'admin deletes the incident' do
@@ -40,7 +38,6 @@ describe 'editing supervisor reports as a supervisor' do
       expect(page).to have_content 'Editing Supervisor Report'
       incident.destroy
       click_button 'Save supervisor report'
-      wait_for_ajax!
       expect(page).to have_selector 'p.notice',
                                     text: 'This incident report no longer exists.'
     end

--- a/spec/system/supervisors/special_supervisor_report_fields_spec.rb
+++ b/spec/system/supervisors/special_supervisor_report_fields_spec.rb
@@ -24,7 +24,6 @@ describe 'special supervisor report fields' do
         check 'Were pictures taken?'
         fill_in 'Number of pictures saved', with: ''
         click_button 'Save supervisor report'
-        wait_for_ajax!
         expect(page).to have_selector 'p.notice',
                                       text: 'Incident report was successfully saved.'
       end
@@ -54,7 +53,6 @@ describe 'special supervisor report fields' do
       it 'requires filling in the witness information' do
         check 'Were there witnesses?'
         click_button 'Save supervisor report'
-        wait_for_ajax!
         expect(page).to have_text "Witnesses name can't be blank"
       end
     end
@@ -65,7 +63,6 @@ describe 'special supervisor report fields' do
         expect(page).to have_text 'Witness Information'
         fill_in 'Name', with: 'Cornelius Fudge'
         click_button 'Save supervisor report'
-        wait_for_ajax!
         expect(page).to have_selector 'p.notice',
                                       text: 'Incident report was successfully saved.'
         expect(page).to have_text 'Cornelius Fudge'
@@ -129,7 +126,6 @@ describe 'special supervisor report fields' do
         uncheck :supervisor_report_fta_threshold_not_met
         uncheck :supervisor_report_driver_discounted
         click_button 'Save supervisor report'
-        wait_for_ajax!
         expect(page)
           .to have_text 'You must provide a reason why no test was conducted.'
       end
@@ -155,7 +151,6 @@ describe 'special supervisor report fields' do
       it 'requires explaining how the FTA threshold was not met' do
         check 'Accident does not meet FTA post-accident testing criteria. Therefore, no drug or alcohol testing is permitted under FTA.'
         click_button 'Save supervisor report'
-        wait_for_ajax!
         expect(page)
           .to have_text 'This supervisor report has 1 missing value and so cannot be marked as completed.'
       end
@@ -193,7 +188,6 @@ describe 'special supervisor report fields' do
         expect(page)
           .to have_text 'Please explain why the driver can be discounted.'
         click_button 'Save supervisor report'
-        wait_for_ajax!
         expect(page)
           .to have_text 'This supervisor report has 1 missing value and so cannot be marked as completed.'
       end


### PR DESCRIPTION
The referenced blog post was from 2016 and since then Capybara has gotten way better at knowing to wait. As long as you use `.find` and the Capybara matchers like `have_text`, `have_selector`, etc. it should be fine.

I also swapped-in `accept_alert` which  waits for the alert to appear.