### PR TITLE
Update i18n fallbacks config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -73,7 +73,7 @@ Rails.application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
+  config.i18n.fallbacks = [I18n.default_locale]
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'simplecov'
 SimpleCov.start 'rails' do
   add_filter '/config/'
   add_filter '/spec/'
+  add_filter '/vendor/'
   refuse_coverage_drop if ENV['CI']
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,6 @@ require 'simplecov'
 SimpleCov.start 'rails' do
   add_filter '/config/'
   add_filter '/spec/'
-  add_filter '/vendor/'
   refuse_coverage_drop if ENV['CI']
 end
 


### PR DESCRIPTION
Saw this while bundling:
> HEADS UP! i18n 1.1 changed fallbacks to exclude default locale.
> But that may break your application.
> 
> If you are upgrading your Rails application from an older version of Rails:
> 
> Please check your Rails app for 'config.i18n.fallbacks = true'.
> If you're using I18n (>= 1.1.0) and Rails (< 5.2.2), this should be
> 'config.i18n.fallbacks = [I18n.default_locale]'.
> If not, fallbacks will be broken in your app by I18n 1.1.x.
> 
> If you are starting a NEW Rails application, you can ignore this notice.
> 
> For more info see:
> https://github.com/svenfuchs/i18n/releases/tag/v1.1.0

We are running `Rails 5.2.4.2` and `i18n 1.8.3`.