### PR TITLE
Testing timeline cleanup. 

### DIFF
--- a/app/assets/javascripts/incident_reports/edit.coffee
+++ b/app/assets/javascripts/incident_reports/edit.coffee
@@ -58,7 +58,7 @@ toggleReasonsForTesting = ->
   showOnly = (field) ->
     infos = [
       '.post-accident-info',
-      '.reasonable-suspician-info',
+      '.reasonable-suspicion-info',
       '.driver-discounted-info',
       '.fta-threshold-info'
     ]
@@ -70,14 +70,18 @@ toggleReasonsForTesting = ->
 
   reason = $('#supervisor_report_test_status').val()
   switch reason
-    when 'Reasonable Suspicion: Completed drug test'
+    when 'Reasonable Suspicion: test completed'
       showOnly('.reasonable-suspicion-info')
-    when 'Post Accident: Threshold met (completed drug test)'
+      $('.test-info').slideDown()
+    when 'Post Accident: Threshold met (test completed)'
       showOnly('.post-accident-info')
-    when 'Post Accident: No threshold met (no drug test)'
+      $('.test-info').slideDown()
+    when 'Post Accident: No threshold met (test not conducted)'
       showOnly('.fta-threshold-info')
-    when 'Post Accident: Threshold met and discounted (no drug test)'
+      $('.test-info').slideUp()
+    when 'Post Accident: Threshold met and discounted (test not conducted)'
       showOnly('.driver-discounted-info')
+      $('.test-info').slideUp()
     else showOnly('nothing')
 
 $(document).on 'turbolinks:load', ->
@@ -107,12 +111,6 @@ $(document).on 'turbolinks:load', ->
 
   $('form').showIfChecked '#supervisor_report_pictures_saved',
                           '.saved-pictures-info'
-
-  $('form').showIfChecked '#supervisor_report_completed_drug_or_alcohol_test',
-                          '.test-info'
-
-  $('form').showIfChecked '#supervisor_report_completed_drug_or_alcohol_test',
-                          '.no-test-info', reverse: true
 
   $('form').showIfChecked '#supervisor_report_fta_threshold_not_met',
                           '.fta-threshold-info'

--- a/app/models/supervisor_report.rb
+++ b/app/models/supervisor_report.rb
@@ -39,7 +39,7 @@ class SupervisorReport < ApplicationRecord
   end
 
   before_save do
-    unless post_accident_completed_drug_test?
+    unless post_accident_completed_test?
       assign_attributes test_due_to_bodily_injury: false,
         test_due_to_disabling_damage: false,
         test_due_to_fatality: false
@@ -92,8 +92,8 @@ class SupervisorReport < ApplicationRecord
     User.find_by(id: last_update.whodunnit).try(:name) || 'Unknown'
   end
 
-  def post_accident_completed_drug_test?
-    test_status.try(:include?, 'Threshold met (completed drug test)')
+  def post_accident_completed_test?
+    test_status.try(:include?, 'Threshold met (test completed)')
   end
 
   def reasonable_suspicion?
@@ -108,12 +108,8 @@ class SupervisorReport < ApplicationRecord
     test_status.try(:include?, 'discounted')
   end
 
-  def no_drug_test?
-    test_status.try(:include, 'no drug test')
-  end
-
-  def post_accident?
-    test_status.try(:include?, 'completed drug test')
+  def test_conducted?
+    test_status.try(:include?, 'test completed')
   end
 
   def timeline

--- a/app/models/supervisor_report.rb
+++ b/app/models/supervisor_report.rb
@@ -4,10 +4,10 @@ class SupervisorReport < ApplicationRecord
   has_paper_trail
 
   REASONS_FOR_TEST = [
-    'Post Accident: Threshold met (completed drug test)',
-    'Post Accident: No threshold met (no drug test)',
-    'Post Accident: Threshold met and discounted (no drug test)',
-    'Reasonable Suspicion: Completed drug test'
+    'Post Accident: Threshold met (test completed)',
+    'Post Accident: No threshold met (test not conducted)',
+    'Post Accident: Threshold met and discounted (test not conducted)',
+    'Reasonable Suspicion: test completed'
   ].freeze
   TESTING_FACILITIES = [
     'Occuhealth East Longmeadow',

--- a/app/views/incidents/show.pdf.prawn
+++ b/app/views/incidents/show.pdf.prawn
@@ -469,12 +469,6 @@ prawn_document do |pdf|
         align: :center, size: 14, style: :bold
     end
 
-    pdf.field_row height: 40, units: 1 do |row|
-      row.check_box_field field: 'Testing scenario', width: 1,
-        options: SupervisorReport::REASONS_FOR_TEST,
-        checked: SupervisorReport::REASONS_FOR_TEST.map{ |c| sup_report.test_status == c },
-        per_column: 2
-    end
     pdf.field_row height: 25, units: 6 do |row|
       row.text_field field: 'Employee', width: 1,
         value: @incident.driver.proper_name,
@@ -488,6 +482,20 @@ prawn_document do |pdf|
       row.text_field field: 'Testing location', width: 2,
         value: sup_report.testing_facility,
         options: { valign: :center }
+    end
+
+    pdf.field_row height: 40, units: 1 do |row|
+      row.check_box_field field: 'Test Conducted', width: 1,
+        options: SupervisorReport::REASONS_FOR_TEST.values_at(0,3),
+        checked: SupervisorReport::REASONS_FOR_TEST.values_at(0,3).map{ |c| sup_report.test_status == c && sup_report.test_conducted? },
+        per_column: 2
+    end
+
+    pdf.field_row height: 40, units: 1 do |row|
+      row.check_box_field field: 'Test Not Conducted', width: 1,
+        options: SupervisorReport::REASONS_FOR_TEST.values_at(1,2),
+        checked: SupervisorReport::REASONS_FOR_TEST.values_at(1,2).map{ |c| sup_report.test_status == c && !sup_report.test_conducted? },
+        per_column: 2
     end
 
     pdf.move_down 15
@@ -546,26 +554,22 @@ prawn_document do |pdf|
 
     pdf.field_row height: 25, units: 1 do |row|
       row.text_field field: 'Type of test', value: 'Drug & Alcohol',
-        options: { if: sup_report.post_accident_completed_drug_test? }
+        options: { if: sup_report.post_accident_completed_test? }
     end
 
-    pdf.field_row height: 75, units: 1 do |row|
+    pdf.field_row height: 50, units: 1 do |row|
       reasons = [
         'BODILY INJURY - requiring immediate medical treatment away from the scene',
         'DISABLING DAMAGE - see note below for definition',
-        'FATALITY - DOT testing is mandatory, no exceptions',
-        'THRESHOLD NOT MET - Accident does not meet FTA post-accident testing criteria.',
-        'DISCOUNTED - I can completely discount the operator, as a contributing factor to the incident.'
+        'FATALITY - DOT testing is mandatory, no exceptions'
       ]
       checked_reasons = [
         sup_report.test_due_to_bodily_injury?,
         sup_report.test_due_to_disabling_damage?,
-        sup_report.test_due_to_fatality?,
-        sup_report.fta_threshold_not_met?,
-        sup_report.driver_discounted?
+        sup_report.test_due_to_fatality?
       ]
       row.check_box_field field: 'Reason for test',
-        options: reasons, checked: checked_reasons, per_column: 5
+        options: reasons, checked: checked_reasons, per_column: 3
     end
 
     pdf.bounding_box [0, pdf.cursor], width: pdf.bounds.width, height: 40 do

--- a/app/views/supervisor_reports/_form.haml
+++ b/app/views/supervisor_reports/_form.haml
@@ -49,75 +49,75 @@
             = witness_form.text_field :work_phone
       %button.btn-default.add-witness Add witness info
       %button.btn-default.delete-witness Delete witness info
-    .test-info
+    .field
+      = form.label :test_status
+      = form.select :test_status,
+        options_for_select(SupervisorReport::REASONS_FOR_TEST, report.test_status), { include_blank: true },
+        id: :supervisor_report_test_status
+    .fta-threshold-info{style: ('display: none;' unless report.fta_threshold_not_met?)}
+      = form.label :reason_threshold_not_met
+      = form.text_area :reason_threshold_not_met, id: :supervisor_report_reason_threshold_not_met,
+        size: '80x4'
+    .driver-discounted-info{style: ('display: none;' unless report.driver_discounted?)}
+      = form.label :reason_driver_discounted
+      = form.text_area :reason_driver_discounted, id: :supervisor_report_reason_driver_discounted,
+        size: '80x4'
+    .post-accident-info{style: ('display: none;' unless report.post_accident_completed_test?)}
       .field
-        = form.label :test_status
-        = form.select :test_status,
-          options_for_select(SupervisorReport::REASONS_FOR_TEST, report.test_status), { include_blank: true },
-          id: :supervisor_report_test_status
-      .fta-threshold-info{style: ('display: none;' unless report.fta_threshold_not_met?)}
-        = form.label :reason_threshold_not_met
-        = form.text_area :reason_threshold_not_met, id: :supervisor_report_reason_threshold_not_met,
-          size: '80x4'
-      .driver-discounted-info{style: ('display: none;' unless report.driver_discounted?)}
-        = form.label :reason_driver_discounted
-        = form.text_area :reason_driver_discounted, id: :supervisor_report_reason_driver_discounted,
-          size: '80x4'
-      .post-accident-info{style: ('display: none;' unless report.post_accident_completed_drug_test?)}
+        = form.label :test_due_to_bodily_injury?
+        = form.check_box :test_due_to_bodily_injury, id: :supervisor_report_test_due_to_bodily_injury
+      .field
+        = form.label :test_due_to_disabling_damage?
+        = form.check_box :test_due_to_disabling_damage, id: :supervisor_report_test_due_to_disabling_damage
+      .field
+        = form.label :test_due_to_fatality?
+        = form.check_box :test_due_to_fatality, id: :supervisor_report_test_due_to_fatality
+    .reasonable-suspicion-info{style: ('display: none;' unless report.reasonable_suspicion?)}
+      .field
+        = form.label :completed_drug_test?
+        = form.check_box :completed_drug_test, id: :supervisor_report_completed_drug_test
+      .field
+        = form.label :completed_alcohol_test?
+        = form.check_box :completed_alcohol_test, id: :supervisor_report_completed_alcohol_test
+      .field
+        = form.label :observation_made_at
+        - a11y_datetime_labels('report_observation_made_at').each do |label|
+          = label
+        = form.datetime_select :observation_made_at, id: :supervisor_report_observation_made_at,
+          prompt: true, ampm: true
+      .field
+        = form.label :test_due_to_employee_appearance?
+        = form.check_box :test_due_to_employee_appearance,
+          id: :supervisor_report_test_due_to_employee_appearance
+      .employee-appearance-info{style: ('display: none;' unless report.test_due_to_employee_appearance?)}
         .field
-          = form.label :test_due_to_bodily_injury?
-          = form.check_box :test_due_to_bodily_injury, id: :supervisor_report_test_due_to_bodily_injury
+          = form.label :employee_appearance
+          = form.text_field :employee_appearance, id: :supervisor_report_employee_appearance
+      .field
+        = form.label :test_due_to_employee_behavior?
+        = form.check_box :test_due_to_employee_behavior,
+          id: :supervisor_report_test_due_to_employee_behavior
+      .employee-behavior-info{style: ('display: none;' unless report.test_due_to_employee_behavior?)}
         .field
-          = form.label :test_due_to_disabling_damage?
-          = form.check_box :test_due_to_disabling_damage, id: :supervisor_report_test_due_to_disabling_damage
+          = form.label :employee_behavior
+          = form.text_field :employee_behavior, id: :supervisor_report_employee_behavior
+      .field
+        = form.label :test_due_to_employee_speech?
+        = form.check_box :test_due_to_employee_speech,
+          id: :supervisor_report_test_due_to_employee_speech
+      .employee-speech-info{style: ('display: none;' unless report.test_due_to_employee_speech?)}
         .field
-          = form.label :test_due_to_fatality?
-          = form.check_box :test_due_to_fatality, id: :supervisor_report_test_due_to_fatality
-      .reasonable-suspicion-info{style: ('display: none;' unless report.reasonable_suspicion?)}
+          = form.label :employee_speech
+          = form.text_field :employee_speech, id: :supervisor_report_employee_speech
+      .field
+        = form.label :test_due_to_employee_odor?
+        = form.check_box :test_due_to_employee_odor,
+          id: :supervisor_report_test_due_to_employee_odor
+      .employee-odor-info{style: ('display: none;' unless report.test_due_to_employee_odor?)}
         .field
-          = form.label :completed_drug_test?
-          = form.check_box :completed_drug_test, id: :supervisor_report_completed_drug_test
-        .field
-          = form.label :completed_alcohol_test?
-          = form.check_box :completed_alcohol_test, id: :supervisor_report_completed_alcohol_test
-        .field
-          = form.label :observation_made_at
-          - a11y_datetime_labels('report_observation_made_at').each do |label|
-            = label
-          = form.datetime_select :observation_made_at, id: :supervisor_report_observation_made_at,
-            prompt: true, ampm: true
-        .field
-          = form.label :test_due_to_employee_appearance?
-          = form.check_box :test_due_to_employee_appearance,
-            id: :supervisor_report_test_due_to_employee_appearance
-        .employee-appearance-info{style: ('display: none;' unless report.test_due_to_employee_appearance?)}
-          .field
-            = form.label :employee_appearance
-            = form.text_field :employee_appearance, id: :supervisor_report_employee_appearance
-        .field
-          = form.label :test_due_to_employee_behavior?
-          = form.check_box :test_due_to_employee_behavior,
-            id: :supervisor_report_test_due_to_employee_behavior
-        .employee-behavior-info{style: ('display: none;' unless report.test_due_to_employee_behavior?)}
-          .field
-            = form.label :employee_behavior
-            = form.text_field :employee_behavior, id: :supervisor_report_employee_behavior
-        .field
-          = form.label :test_due_to_employee_speech?
-          = form.check_box :test_due_to_employee_speech,
-            id: :supervisor_report_test_due_to_employee_speech
-        .employee-speech-info{style: ('display: none;' unless report.test_due_to_employee_speech?)}
-          .field
-            = form.label :employee_speech
-            = form.text_field :employee_speech, id: :supervisor_report_employee_speech
-        .field
-          = form.label :test_due_to_employee_odor?
-          = form.check_box :test_due_to_employee_odor,
-            id: :supervisor_report_test_due_to_employee_odor
-        .employee-odor-info{style: ('display: none;' unless report.test_due_to_employee_odor?)}
-          .field
-            = form.label :employee_odor
-            = form.text_field :employee_odor, id: :supervisor_report_employee_odor
+          = form.label :employee_odor
+          = form.text_field :employee_odor, id: :supervisor_report_employee_odor
+    .test-info{style: ('display: none;' unless report.test_conducted?)}
       .field
         = form.label :testing_facility
         = form.select :testing_facility,
@@ -178,28 +178,28 @@
           = label
         = form.datetime_select :employee_returned_to_work_or_released_from_duty_at,
           id: :supervisor_report_employee_returned_to_work_or_released_from_duty_at, ampm: true, prompt: true
-      %strong If applicable:
-      .field
-        = form.label :superintendent_notified_at
-        - a11y_datetime_labels('report_superintendent_notified_at').each do |label|
-          = label
-        = form.datetime_select :superintendent_notified_at,
-          id: :supervisor_report_superintendent_notified_at, ampm: true, prompt: true
-      .field
-        = form.label :program_manager_notified_at
-        - a11y_datetime_labels('report_program_manager_notified_at').each do |label|
-          = label
-        = form.datetime_select :program_manager_notified_at,
-          id: :supervisor_report_program_manager_notified_at, ampm: true, prompt: true
-      .field
-        = form.label :director_notified_at
-        - a11y_datetime_labels('report_director_notified_at').each do |label|
-          = label
-        = form.datetime_select :director_notified_at,
-          id: :supervisor_report_director_notified_at, ampm: true, prompt: true
-      .field
-        = form.label :amplifying_comments
-        = form.text_area :amplifying_comments, id: :supervisor_report_amplifying_comments,
-          size: '80x4'
+    %strong If applicable:
+    .field
+      = form.label :superintendent_notified_at
+      - a11y_datetime_labels('report_superintendent_notified_at').each do |label|
+        = label
+      = form.datetime_select :superintendent_notified_at,
+        id: :supervisor_report_superintendent_notified_at, ampm: true, prompt: true
+    .field
+      = form.label :program_manager_notified_at
+      - a11y_datetime_labels('report_program_manager_notified_at').each do |label|
+        = label
+      = form.datetime_select :program_manager_notified_at,
+        id: :supervisor_report_program_manager_notified_at, ampm: true, prompt: true
+    .field
+      = form.label :director_notified_at
+      - a11y_datetime_labels('report_director_notified_at').each do |label|
+        = label
+      = form.datetime_select :director_notified_at,
+        id: :supervisor_report_director_notified_at, ampm: true, prompt: true
+    .field
+      = form.label :amplifying_comments
+      = form.text_area :amplifying_comments, id: :supervisor_report_amplifying_comments,
+        size: '80x4'
     .actions
       = form.submit 'Save supervisor report'

--- a/app/views/supervisor_reports/_show.haml
+++ b/app/views/supervisor_reports/_show.haml
@@ -46,7 +46,7 @@
     %p
       %strong= human_name :supervisor_report, :reason_threshold_not_met
       = simple_format report.reason_threshold_not_met
-- if report.post_accident_completed_drug_test?
+- if report.post_accident_completed_test?
   %p
     %strong= human_name :supervisor_report, :test_due_to_bodily_injury?
     = yes_no_image report.test_due_to_bodily_injury?
@@ -94,33 +94,34 @@
     %p
       %strong= human_name :supervisor_report, :employee_odor
       = report.employee_odor
-%p
-  %strong= human_name :supervisor_report, :testing_facility
-  = report.testing_facility
-- if report.testing_facility_notified_at.present?
+- if report.test_conducted?
   %p
-    %strong= human_name :supervisor_report, :testing_facility_notified_at
-    = report.testing_facility_notified_at.strftime '%l:%M %P'
-- if report.employee_notified_of_test_at.present?
-  %p
-    %strong= human_name :supervisor_report, :employee_notified_of_test_at
-    = report.employee_notified_of_test_at.strftime '%l:%M %P'
-- if report.employee_departed_to_test_at.present?
-  %p
-    %strong= human_name :supervisor_report, :employee_departed_to_test_at
-    = report.employee_departed_to_test_at.strftime '%l:%M %P'
-- if report.employee_arrived_at_test_at.present?
-  %p
-    %strong= human_name :supervisor_report, :employee_arrived_to_test_at
-    = report.employee_arrived_at_test_at.strftime '%l:%M %P'
-- if report.test_started_at.present?
-  %p
-    %strong= human_name :supervisor_report, :test_started_at
-    = report.test_started_at.strftime '%l:%M %P'
-- if report.test_ended_at.present?
-  %p
-    %strong= human_name :supervisor_report, :test_ended_at
-    = report.test_ended_at.strftime '%l:%M %P'
+    %strong= human_name :supervisor_report, :testing_facility
+    = report.testing_facility
+  - if report.testing_facility_notified_at.present?
+    %p
+      %strong= human_name :supervisor_report, :testing_facility_notified_at
+      = report.testing_facility_notified_at.strftime '%l:%M %P'
+  - if report.employee_notified_of_test_at.present?
+    %p
+      %strong= human_name :supervisor_report, :employee_notified_of_test_at
+      = report.employee_notified_of_test_at.strftime '%l:%M %P'
+  - if report.employee_departed_to_test_at.present?
+    %p
+      %strong= human_name :supervisor_report, :employee_departed_to_test_at
+      = report.employee_departed_to_test_at.strftime '%l:%M %P'
+  - if report.employee_arrived_at_test_at.present?
+    %p
+      %strong= human_name :supervisor_report, :employee_arrived_to_test_at
+      = report.employee_arrived_at_test_at.strftime '%l:%M %P'
+  - if report.test_started_at.present?
+    %p
+      %strong= human_name :supervisor_report, :test_started_at
+      = report.test_started_at.strftime '%l:%M %P'
+  - if report.test_ended_at.present?
+    %p
+      %strong= human_name :supervisor_report, :test_ended_at
+      = report.test_ended_at.strftime '%l:%M %P'
 - if report.superintendent_notified_at.present?
   %p
     %strong= human_name :supervisor_report, :superintendent_notified_at

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 84.58
+    "covered_percent": 84.67
   }
 }

--- a/spec/requests/printing_incidents_spec.rb
+++ b/spec/requests/printing_incidents_spec.rb
@@ -78,7 +78,7 @@ describe 'IncidentsController#show PDF' do
     expect(response.media_type).to eq 'application/pdf'
   end
   it 'prints an incident, no drug test, not FTA threshold' do
-    sup_report = create :supervisor_report, test_status: 'Post Accident: No threshold met (no drug test)',
+    sup_report = create :supervisor_report, test_status: 'Post Accident: No threshold met (test not conducted)',
       reason_threshold_not_met: 'Because I said so.'
     incident = create :incident, supervisor_report: sup_report
     incident.driver_incident_report.update user: driver
@@ -88,7 +88,7 @@ describe 'IncidentsController#show PDF' do
     expect(response.media_type).to eq 'application/pdf'
   end
   it 'prints an incident, no drug test, discounted' do
-    sup_report = create :supervisor_report, test_status: 'Post Accident: Threshold met and discounted (no drug test)',
+    sup_report = create :supervisor_report, test_status: 'Post Accident: Threshold met and discounted (test not conducted)',
       reason_driver_discounted: 'Because I said so.'
     incident = create :incident, supervisor_report: sup_report
     incident.driver_incident_report.update user: driver

--- a/spec/system/supervisors/special_supervisor_report_fields_spec.rb
+++ b/spec/system/supervisors/special_supervisor_report_fields_spec.rb
@@ -69,43 +69,31 @@ describe 'special supervisor report fields' do
     context 'with test conducted' do
       it 'allows filling in the reason for testing', js: true do
         visit edit_supervisor_report_url(incident.supervisor_report)
-        select 'Post Accident: Threshold met (completed drug test)', from: 'Test status'
-        within('.test-info') do
+        select 'Post Accident: Threshold met (test completed)', from: 'Test status'
+        within('.post-accident-info') do
           expect(page).to have_text 'bodily injury'
-          expect(page).to have_text 'disabling damage'
-          expect(page).to have_text 'fatality'
-          expect(page).not_to have_text 'Completed alcohol test'
-          expect(page).not_to have_text 'Observation made at'
-          expect(page).not_to have_text 'Observation made at'
-          %w[appearance behavior speech odor].each do |reason|
-            expect(page).not_to have_text "Test due to employee #{reason}"
-          end
         end
+        expect(page).not_to have_text 'Completed alcohol test'
+        expect(page).to have_text 'Testing Timeline'
         select 'Reasonable Suspicion', from: 'Test status'
-        within('.test-info') do
-          expect(page).not_to have_text 'bodily injury'
-          expect(page).not_to have_text 'disabling damage'
-          expect(page).not_to have_text 'fatality'
+        expect(page).not_to have_text 'bodily injury'
+        expect(page).to have_text 'Testing Timeline'
+        within('.reasonable-suspicion-info') do
           expect(page).to have_text 'Completed drug test'
-          expect(page).to have_text 'Completed alcohol test'
-          expect(page).to have_text 'Observation made at'
-          expect(page).to have_text 'Observation made at'
-          %w[appearance behavior speech odor].each do |reason|
-            expect(page).to have_text "Test due to employee #{reason}"
-          end
         end
-        select 'Post Accident: Threshold met and discounted', from: 'Test status'
-        within('.test-info') do
-          expect(page).not_to have_text 'bodily injury'
-          expect(page).not_to have_text 'disabling damage'
-          expect(page).not_to have_text 'fatality'
+        select 'Post Accident: Threshold met and discounted (test not conducted)', from: 'Test status'
+        expect(page).not_to have_text 'bodily injury'
+        expect(page).not_to have_text 'Completed drug test'
+        expect(page).not_to have_text 'Testing Timeline'
+        within('.driver-discounted-info') do
           expect(page).to have_text 'Please explain why the driver can be discounted.'
         end
         select 'No threshold met', from: 'Test status'
-        within('.test-info') do
-          expect(page).not_to have_text 'bodily injury'
-          expect(page).not_to have_text 'disabling damage'
-          expect(page).not_to have_text 'fatality'
+        expect(page).not_to have_text 'bodily injury'
+        expect(page).not_to have_text 'Completed drug test'
+        expect(page).not_to have_text 'Please explain why the driver can be discounted.'
+        expect(page).not_to have_text 'Testing Timeline'
+        within('.fta-threshold-info') do
           expect(page).to have_text 'Please explain how the FTA threshold is not met.'
         end
       end


### PR DESCRIPTION
It was requested that there be a checkbox specifically called "no test conducted". I sent an email to the person who made the request to verify if these changes were integrated into Tanvish's changes to the timeline in a way that is desired. This person no longer works for the PVTA so guess reviewers can decide if this branch should be merged. I changed wording for the test status drop down to include whether or not a test was conducted. I also changed some of the javascript to only display the relevant fields depending on the test status. Then I updated the PDF.
<img width="822" alt="Screen Shot 2020-10-06 at 3 00 38 PM" src="https://user-images.githubusercontent.com/28609962/95248176-eae8df00-07e4-11eb-9b33-292df3094e5b.png">

If no test is conducted then the testing timeline is not shown. 
<img width="1369" alt="Screen Shot 2020-10-06 at 3 00 50 PM" src="https://user-images.githubusercontent.com/28609962/95248184-ee7c6600-07e4-11eb-958e-e89f770e98a7.png">

<img width="782" alt="Screen Shot 2020-10-06 at 3 01 35 PM" src="https://user-images.githubusercontent.com/28609962/95248194-f20fed00-07e4-11eb-86e6-4e1df31cbb9c.png">


