### PR TITLE
Add occurred at to incidents

### DIFF
--- a/app/models/incident.rb
+++ b/app/models/incident.rb
@@ -22,6 +22,7 @@ class Incident < ApplicationRecord
   # belongs_to :reason_code, optional: { unless: :completed? }
   belongs_to :reason_code, optional: true
   belongs_to :supplementary_reason_code, optional: true
+  validates :occurred_at, presence: true
   validates :reason_code, :supplementary_reason_code, :root_cause_analysis, :latitude, :longitude,
     presence: true, if: :completed?
 
@@ -31,7 +32,6 @@ class Incident < ApplicationRecord
   validate :supervisor_in_correct_group
 
   accepts_nested_attributes_for :driver_incident_report
-  validates :occurred_at, presence: true, on: :create
   accepts_nested_attributes_for :supervisor_incident_report
   accepts_nested_attributes_for :supervisor_report
 

--- a/app/models/incident_report.rb
+++ b/app/models/incident_report.rb
@@ -52,7 +52,7 @@ class IncidentReport < ApplicationRecord
 
   accepts_nested_attributes_for :injured_passengers
 
-  validates :occurred_at, :location, :direction, :town, :bus, :description,
+  validates :location, :direction, :town, :bus, :description,
     presence: true, if: :changed?, unless: :new_record?
   validates :run, length: { maximum: 5 }
   validates :location, length: { maximum: 50 }
@@ -93,18 +93,6 @@ class IncidentReport < ApplicationRecord
 
   def needs_reason_not_up_to_curb?
     motion_of_bus == 'Stopped' && !bus_up_to_curb?
-  end
-
-  def occurred_at_readable
-    [occurred_date, occurred_time].join ' - '
-  end
-
-  def occurred_date
-    occurred_at.try :strftime, '%A, %B %e'
-  end
-
-  def occurred_time
-    occurred_at.try :strftime, '%l:%M %P'
   end
 
   # rubocop:disable Metrics/LineLength

--- a/app/views/incident_reports/_form.html.haml
+++ b/app/views/incident_reports/_form.html.haml
@@ -20,12 +20,6 @@
           options_from_collection_for_select(users, :id, :proper_name, report.user_id),
           { include_blank: true }, id: :incident_report_user_id
     .field
-      = form.label :occurred_at
-      - a11y_datetime_labels('incident_report_occurred_at').each do |label|
-        = label
-      = form.datetime_select :occurred_at, id: :incident_report_occurred_at,
-        prompt: true, ampm: true
-    .field
       = form.label :run
       = form.text_field :run, id: :incident_report_run
       .example C57; VATCo always uses CAPITAL route letter and number; no symbols

--- a/app/views/incident_reports/_show.haml
+++ b/app/views/incident_reports/_show.haml
@@ -30,9 +30,6 @@
   %strong= human_name :incident, :bus
   = report.bus
 %p
-  %strong= human_name :incident_report, :occurred_at
-  = report.occurred_at_readable
-%p
   %strong= human_name :incident_report, :passengers_onboard
   = report.passengers_onboard
 %p

--- a/app/views/incidents/_incident.xml.haml
+++ b/app/views/incidents/_incident.xml.haml
@@ -6,10 +6,10 @@
     %ai_code= incident.reason_code.identifier
   - if incident.root_cause_analysis.present?
     %ai_commentary= incident.root_cause_analysis
-  - if report.occurred_at.present?
-    %ai_date_occured= report.occurred_at.strftime '%Y-%m-%d'
-    %ai_time_occured= report.occurred_at.strftime '2000-01-01T%H:%M:00.000'
-    %ai_occured_year= report.occurred_at.year
+  - if incident.occurred_at.present?
+    %ai_date_occured= incident.occurred_at.strftime '%Y-%m-%d'
+    %ai_time_occured= incident.occurred_at.strftime '2000-01-01T%H:%M:00.000'
+    %ai_occured_year= incident.occurred_at.year
   - if report.direction.present? && report.direction != 'NA'
     %ai_direction= report.direction
   - if report.town.present?

--- a/app/views/incidents/new.html.haml
+++ b/app/views/incidents/new.html.haml
@@ -9,6 +9,13 @@
       - @incident.errors.full_messages.each do |message|
         %li= message
 = form_with model: @incident, local: true do |form|
+  .field
+    = form.label :occurred_at
+    - a11y_datetime_labels('incident_attributes_occurred_at').each do |label|
+      = label
+    = form.datetime_select :occurred_at, id: :incident_attributes_occurred_at,
+      prompt: true, ampm: true
+  - unless current_user.driver?
   = form.fields_for :driver_incident_report, IncidentReport.new do |driver_form|
     .field
       = driver_form.label :user_id, 'Driver'
@@ -16,12 +23,6 @@
         options_from_collection_for_select(@drivers, :id, :proper_name, current_user.id),
         { include_blank: true },
         id: :incident_driver_incident_report_attributes_user_id
-    .field
-      = driver_form.label :occurred_at
-      - a11y_datetime_labels('incident_driver_incident_report_attributes_occurred_at').each do |label|
-        = label
-      = driver_form.datetime_select :occurred_at, id: :incident_driver_incident_report_attributes_occurred_at,
-        prompt: true, ampm: true
   = form.fields_for :supervisor_incident_report, IncidentReport.new do |supervisor_form|
     .field
       = supervisor_form.label :user_id, 'Supervisor'

--- a/app/views/incidents/new.html.haml
+++ b/app/views/incidents/new.html.haml
@@ -11,24 +11,24 @@
 = form_with model: @incident, local: true do |form|
   .field
     = form.label :occurred_at
-    - a11y_datetime_labels('incident_attributes_occurred_at').each do |label|
+    - a11y_datetime_labels('incident_occurred_at').each do |label|
       = label
-    = form.datetime_select :occurred_at, id: :incident_attributes_occurred_at,
+    = form.datetime_select :occurred_at, id: :incident_occurred_at,
       prompt: true, ampm: true
   - unless current_user.driver?
-  = form.fields_for :driver_incident_report, IncidentReport.new do |driver_form|
-    .field
-      = driver_form.label :user_id, 'Driver'
-      = driver_form.select :user_id,
-        options_from_collection_for_select(@drivers, :id, :proper_name, current_user.id),
-        { include_blank: true },
-        id: :incident_driver_incident_report_attributes_user_id
-  = form.fields_for :supervisor_incident_report, IncidentReport.new do |supervisor_form|
-    .field
-      = supervisor_form.label :user_id, 'Supervisor'
-      = supervisor_form.select :user_id,
-        options_from_collection_for_select(@supervisors, :id, :proper_name, current_user.id),
-        { include_blank: true },
-        id: :incident_supervisor_incident_report_attributes_user_id
+    = form.fields_for :driver_incident_report, IncidentReport.new do |driver_form|
+      .field
+        = driver_form.label :user_id, 'Driver'
+        = driver_form.select :user_id,
+          options_from_collection_for_select(@drivers, :id, :proper_name, current_user.id),
+          { include_blank: true },
+          id: :incident_driver_incident_report_attributes_user_id
+    = form.fields_for :supervisor_incident_report, IncidentReport.new do |supervisor_form|
+      .field
+        = supervisor_form.label :user_id, 'Supervisor'
+        = supervisor_form.select :user_id,
+          options_from_collection_for_select(@supervisors, :id, :proper_name, current_user.id),
+          { include_blank: true },
+          id: :incident_supervisor_incident_report_attributes_user_id
   .actions= form.submit 'Create Incident Report'
 = link_to 'Back', incidents_path

--- a/app/views/incidents/show.html.haml
+++ b/app/views/incidents/show.html.haml
@@ -16,6 +16,9 @@
   %p
     %strong= human_name :incident, :completed
     = yes_no_image @incident.completed?
+  %p
+    %strong= human_name :incident, :occurred_at
+    = @incident.occurred_at_readable
 
   - if @incident.completed?
     %p

--- a/app/views/incidents/show.pdf.prawn
+++ b/app/views/incidents/show.pdf.prawn
@@ -36,8 +36,8 @@ prawn_document do |pdf|
   end
 
   pdf.field_row height: 30, units: 6 do |row|
-    row.text_field field: 'Date of Incident', value: report.occurred_at.try(:strftime, '%m/%d/%Y')
-    row.text_field field: 'Time of Incident', value: report.occurred_time
+    row.text_field field: 'Date of Incident', value: @incident.occurred_at.try(:strftime, '%m/%d/%Y')
+    row.text_field field: 'Time of Incident', value: @incident.occurred_time
     row.text_field field: '# passengers on bus', value: report.passengers_onboard
     row.text_field field: '# courtesy cards distributed', value: report.courtesy_cards_distributed
     row.text_field field: '# courtesy cards attached', value: report.courtesy_cards_collected
@@ -217,7 +217,7 @@ prawn_document do |pdf|
       row.text_field width: 4, field: 'Operator', value: report.user.proper_name
       row.text_field field: 'Badge No.', value: report.user.badge_number
       row.text_field field: 'Bus #', value: report.bus
-      row.text_field width: 2, field: 'Date of Incident', value: report.occurred_at.try(:strftime, '%m/%d/%Y')
+      row.text_field width: 2, field: 'Date of Incident', value: @incident.occurred_at.try(:strftime, '%m/%d/%Y')
     end
 
     pdf.field_row height: pdf.cursor - 30, units: 1 do |row|
@@ -279,8 +279,8 @@ prawn_document do |pdf|
     end
 
     pdf.field_row height: 30, units: 7 do |row|
-      row.text_field field: 'Date of Incident', value: report.occurred_at.try(:strftime, '%m/%d/%Y')
-      row.text_field field: 'Time of Incident', value: report.occurred_time
+      row.text_field field: 'Date of Incident', value: @incident.occurred_at.try(:strftime, '%m/%d/%Y')
+      row.text_field field: 'Time of Incident', value: @incident.occurred_time
       row.text_field field: '# passengers on bus', value: report.passengers_onboard
       row.text_field field: '# courtesy cards distributed', value: report.courtesy_cards_distributed
       row.text_field field: '# courtesy cards attached', value: report.courtesy_cards_collected
@@ -480,7 +480,7 @@ prawn_document do |pdf|
         value: @incident.driver.proper_name,
         options: { valign: :center }
       row.text_field field: 'Date and time of incident', width: 2,
-        value: report.occurred_at.try(:strftime, '%B %e, %Y %-l:%M %P'),
+        value: @incident.occurred_at.try(:strftime, '%B %e, %Y %-l:%M %P'),
         options: { valign: :center }
       row.text_field field: 'Location of incident', width: 1,
         value: report.location,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,7 +14,6 @@ en:
         block: 'Block #'
         bus: 'Bus #'
         zip: 'ZIP'
-        occurred_at: 'Date and time of incident'
         speed: 'Speed at time of incident'
         motor_vehicle_collision?: 'Did the incident involve a collision?'
         passenger_incident?: 'Did the incident involve a passenger?'

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 87.86
+    "covered_percent": 87.58
   }
 }

--- a/db/migrate/20201230173222_add_occurred_at_to_incidents.rb
+++ b/db/migrate/20201230173222_add_occurred_at_to_incidents.rb
@@ -1,0 +1,5 @@
+class AddOccurredAtToIncidents < ActiveRecord::Migration[5.2]
+  def change
+    add_column :incidents, :occurred_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_15_141905) do
+ActiveRecord::Schema.define(version: 2020_12_30_173222) do
 
   create_table "divisions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -143,6 +143,7 @@ ActiveRecord::Schema.define(version: 2020_07_15_141905) do
     t.integer "claims_id"
     t.boolean "exported_to_claims"
     t.integer "supplementary_reason_code_id"
+    t.datetime "occurred_at"
   end
 
   create_table "injured_passengers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/lib/tasks/occurred_at.rake
+++ b/lib/tasks/occurred_at.rake
@@ -1,0 +1,11 @@
+namespace :incidents do
+  desc 'move occurred_at to incidents'
+  task move_occurred_at: :environment do
+    Incident.all.each do |incident|
+      if incident.driver_incident_report?
+        occurred_at = incident.driver_incident_report.occurred_at
+        incident.update(occurred_at: occurred_at)
+      end
+    end
+  end
+end

--- a/spec/factories/incident_reports.rb
+++ b/spec/factories/incident_reports.rb
@@ -21,7 +21,6 @@ FactoryBot.define do
     road_conditions            { IncidentReport::ROAD_OPTIONS.sample }
     light_conditions           { IncidentReport::LIGHT_OPTIONS.sample }
     description                { FFaker::Lorem.paragraphs(5).join "\n" }
-    occurred_at { DateTime.now.beginning_of_minute }
 
     trait :driver_report do
       association :user, factory: %i[user driver]

--- a/spec/factories/incidents.rb
+++ b/spec/factories/incidents.rb
@@ -2,6 +2,7 @@
 
 FactoryBot.define do
   factory :incident do
+    occurred_at { DateTime.now.beginning_of_minute }
     association :driver_incident_report,
                 factory: %i[incident_report driver_report]
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,7 +63,6 @@ RSpec.configure do |config|
 end
 
 def fill_in_base_incident_fields
-  fill_in_date_and_time
   fill_in 'Bus #', with: '1803'
   fill_in 'Location', with: 'Mill and Locust'
   fill_in 'ZIP', with: '01108'

--- a/spec/system/drivers/creating_incidents_spec.rb
+++ b/spec/system/drivers/creating_incidents_spec.rb
@@ -4,20 +4,30 @@ require 'spec_helper'
 
 describe 'creating incidents as a driver' do
   before(:each) { when_current_user_is :driver }
-  it 'brings drivers directly to the form', js: true do
+  let :new_incident do
+    visit new_incident_url
+    fill_in_date_and_time
+    click_on 'Create Incident Report'
+  end
+  it 'prompts to input the date before redirecting to driver report', js: true do
     visit incidents_url
     find('button', text: 'New Incident').click
+    expect(page).to have_text 'New Incident'
+    click_on 'Create Incident Report'
+    expect(page).to have_text "Date and time of incident can't be blank"
+    fill_in_date_and_time
+    click_on 'Create Incident Report'
     expect(page).to have_text 'Editing Driver Account of Incident'
     driver_report = Incident.last.driver_incident_report
     expect(page.current_url).to end_with edit_incident_report_path(driver_report)
   end
 
+
   it 'requires base fields', js: true do
-    visit new_incident_url
+    new_incident
     save_and_preview
 
-    expect(page).to have_text 'This incident report has 6 missing values and so cannot be marked as completed.'
-    expect(page).to have_text "Date and time of incident can't be blank"
+    expect(page).to have_text 'This incident report has 5 missing values and so cannot be marked as completed.'
     expect(page).to have_text "Location can't be blank"
     expect(page).to have_text "Town can't be blank"
     expect(page).to have_text "Bus # can't be blank"
@@ -26,7 +36,7 @@ describe 'creating incidents as a driver' do
   end
 
   it 'only requires bus, location, and town', js: true do
-    visit new_incident_url
+    new_incident
     fill_in_base_incident_fields
     save_and_preview
 

--- a/spec/system/drivers/special_incident_fields_spec.rb
+++ b/spec/system/drivers/special_incident_fields_spec.rb
@@ -5,11 +5,16 @@ require 'spec_helper'
 describe 'special incident fields' do
   let(:driver) { create :user, :driver }
   before(:each) { when_current_user_is driver }
+  let :create_new_incident do
+    visit new_incident_url
+    fill_in_date_and_time
+    click_on 'Create Incident Report'
+  end
 
   describe 'collision related fields' do
     context 'without collision' do
       before :each do
-        visit new_incident_path
+        create_new_incident
       end
       it 'allows filling in collision fields', js: true do
         expect(page).not_to have_text 'Motor Vehicle Collision Information'
@@ -43,7 +48,7 @@ describe 'special incident fields' do
   describe 'other vehicle related fields' do
     context 'without other vehicle info' do
       it 'allows filling in other vehicle info as necessary', js: true do
-        visit new_incident_path
+        create_new_incident
         check 'Did the incident involve a collision?'
         expect(page).to have_field 'Other vehicle owner name'
         check 'Is the other driver involved the owner of the vehicle?'
@@ -69,7 +74,7 @@ describe 'special incident fields' do
   describe 'police related fields' do
     context 'without police info' do
       before :each do
-        visit new_incident_path
+        create_new_incident
       end
       it 'allows filling in police info', js: true do
         check 'Did the incident involve a collision?'
@@ -106,7 +111,7 @@ describe 'special incident fields' do
   describe 'passenger incident related fields' do
     context 'without passenger incidents' do
       before :each do
-        visit new_incident_path
+        create_new_incident
       end
       it 'allows filling in passenger incident fields', js: true do
         expect(page).not_to have_text 'Passenger Incident Information'
@@ -139,7 +144,7 @@ describe 'special incident fields' do
 
   describe 'reason not up to curb related fields' do
     before :each do
-      visit new_incident_path
+      create_new_incident
     end
     context 'without reason not up to curb' do
       it 'allows filling in reason bus was not up to curb', js: true  do
@@ -176,4 +181,3 @@ describe 'special incident fields' do
     end
   end
 end
-


### PR DESCRIPTION
I moved the field occurred_at from incident_report to incidents. The driver now has has to input a date and time before being redirected to filling out their incident_report. This is part one of two PRs to close #288. 
<img width="888" alt="Screen Shot 2021-01-01 at 2 10 27 PM" src="https://user-images.githubusercontent.com/28609962/103444867-273ca780-4c3b-11eb-9f56-340491934cf1.png">
