### PR TITLE
Use the https address for the repo

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,7 +1,7 @@
 lock '~> 3.14'
 
 set :application, 'incidents'
-set :repo_url, 'git@github.com:umts/incidents.git'
+set :repo_url, 'https://github.com/umts/incidents.git'
 set :branch, :master
 set :keep_releases, 5
 set :deploy_to, "/srv/#{fetch :application}"

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,2 +1,5 @@
-server 'incidents.pvta.com', roles: %w(app db web)
+server 'incidents.pvta.com',
+  roles: %w[app db web],
+  ssh_options: { forward_agent: false }
+
 set :passenger_restart_with_touch, true


### PR DESCRIPTION
Rather than the SSH one. It's a public repo, why introduce the complexity of agent forwarding to the process?