### PR TITLE
Add nonce value to stylesheet tags

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,10 @@
     %meta{content: 'text/html; charset=UTF-8', 'http-equiv': 'Content-Type'}
     %title Incidents
     = csrf_meta_tags
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', nonce: true, data: { turbolinks_track: 'reload' }
+    = stylesheet_link_tag    'application', media: 'all',
+      nonce: content_security_policy_nonce, data: { turbolinks_track: 'reload' }
+    = javascript_include_tag 'application',
+      nonce: true, data: { turbolinks_track: 'reload' }
     %script{ src: maps_source, nonce: content_security_policy_nonce }
     = favicon_link_tag
   %body

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,7 +4,7 @@
     %meta{content: 'text/html; charset=UTF-8', 'http-equiv': 'Content-Type'}
     %title Incidents
     = csrf_meta_tags
-    = stylesheet_link_tag    'application', media: 'all',
+    = stylesheet_link_tag 'application', media: 'all',
       nonce: content_security_policy_nonce, data: { turbolinks_track: 'reload' }
     = javascript_include_tag 'application',
       nonce: true, data: { turbolinks_track: 'reload' }


### PR DESCRIPTION
This, it turns out was a thing Google changed sometime pretty close to when #316 was reported. Hence, why I was pretty sure that I had gotten it to work in the past.

Before approximately June, 2021, the GMaps JS would look at the nonce value on it's own `<script>` tag and add that value to all the other `<script>` and `<style>` tags that it inserts.  After then, they decided that, because the nonce for JS and the nonce for CSS can be different, it should use the nonce value from some other style tag for its own `<style>` tags.

Closes #316, and for some reason appears to close #315