### PR TITLE
Add rubocop plugins and haml-lint

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -1,0 +1,3 @@
+linters:
+  LineLength:
+    max: 120

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,8 @@
+require:
+  - rubocop-performance
+  - rubocop-rails
+  - rubocop-rspec
+
 AllCops:
   Exclude:
     - Rakefile
@@ -10,19 +15,65 @@ AllCops:
   NewCops: enable
 
 Metrics/AbcSize:
-  Max: 36
+  CountRepeatedAttributes: false
 
 Metrics/BlockLength:
-  Max: 50
-  Exclude:
-    - 'spec/**/*.rb'
+  CountAsOne:
+    - array
+    - hash
+    - heredoc
+  IgnoredMethods:
+    - configure
+
+    # ActiveSupport::Concern
+    - class_methods
+    - included
+    - prepended
+
+    # FactoryBot
+    - define
+    - factory
+    - trait
+
+    # Gemfile
+    - group
+
+    # Rake
+    - namespace
+    - task
+
+    # RSpec
+    - before
+    - context
+    - describe
+    - it
 
 Metrics/ClassLength:
-  Max: 125
+  CountAsOne:
+    - array
+    - hash
+    - heredoc
 
 Metrics/MethodLength:
-  Max: 18
+  CountAsOne:
+    - array
+    - hash
+    - heredoc
 
-# Not bothering for this repo.
+Metrics/ModuleLength:
+  CountAsOne:
+    - array
+    - hash
+    - heredoc
+
 Style/Documentation:
+  Enabled: false
+
+Style/ModuleFunction:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Max: 4
+
+RSpec/MultipleMemoizedHelpers:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -35,8 +35,12 @@ group :development do
   gem 'capistrano-rails', require: false
   gem 'capistrano-sidekiq', require: false
   gem 'ed25519', '>= 1.2', '< 2.0', require: false
+  gem 'haml_lint', require: false
   gem 'listen'
-  gem 'rubocop'
+  gem 'rubocop', require: false
+  gem 'rubocop-performance', require: false
+  gem 'rubocop-rails', require: false
+  gem 'rubocop-rspec', require: false
   gem 'web-console', '>= 3.3.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,6 +149,12 @@ GEM
       haml (>= 4.0.6, < 6.0)
       html2haml (>= 1.0.1)
       railties (>= 5.1)
+    haml_lint (0.37.1)
+      haml (>= 4.0, < 5.3)
+      parallel (~> 1.10)
+      rainbow
+      rubocop (>= 0.50.0)
+      sysexits (~> 1.1)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
       haml (>= 4.0, < 6)
@@ -280,6 +286,16 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.4.1)
       parser (>= 2.7.1.5)
+    rubocop-performance (1.13.0)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    rubocop-rails (2.13.0)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.7.0, < 2.0)
+    rubocop-rspec (2.4.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
     ruby_parser (3.15.1)
       sexp_processor (~> 4.9)
@@ -321,6 +337,7 @@ GEM
     sshkit (1.21.2)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    sysexits (1.2.0)
     temple (0.8.2)
     thor (1.1.0)
     tilt (2.0.10)
@@ -374,6 +391,7 @@ DEPENDENCIES
   factory_bot_rails (~> 4.8.2)
   ffaker (~> 2.7.0)
   haml-rails
+  haml_lint
   jbuilder (~> 2.5)
   listen
   mysql2
@@ -386,6 +404,9 @@ DEPENDENCIES
   rails (~> 6.1.3)
   rspec-rails
   rubocop
+  rubocop-performance
+  rubocop-rails
+  rubocop-rspec
   sass-rails (~> 5.0)
   sidekiq (~> 6.2.1)
   simplecov (~> 0.15)
@@ -399,4 +420,4 @@ RUBY VERSION
    ruby 3.0.1p64
 
 BUNDLED WITH
-   2.2.16
+   2.3.3


### PR DESCRIPTION
Added those linting gems and modified the `.rubocop.yml` to be consistent with round-three.