### PR TITLE
Add maps domain to CSP `connect-src`

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -11,6 +11,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.object_src  :none
   policy.script_src  :self, 'https://*.googleapis.com'
   policy.style_src   :self, 'https://*.googleapis.com'
+  policy.connect_src :self, 'https://*.googleapis.com'
   # If you are using webpack-dev-server then specify webpack-dev-server host
   # policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
 


### PR DESCRIPTION
Google Maps, apparently, makes outgoing connections to itself. So, that needs to be allowed too see:

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src

I don't know that this is causing any actual issues, but @sherson noticed that it was being blocked while troubleshooting our Maps API key. Closes #336 