### PR TITLE
Check `SuperVisorReport.test_status` string presence in PDF

### DIFF
--- a/app/views/incidents/show.pdf.prawn
+++ b/app/views/incidents/show.pdf.prawn
@@ -583,7 +583,7 @@ prawn_document do |pdf|
       DESCRIPTION
     end
 
-    if sup_report.test_status
+    if sup_report.test_status.present?
       pdf.bounding_box [0, pdf.cursor], width: pdf.bounds.width, height: 30 do
         pdf.move_down 15
         pdf.text 'POST-ACCIDENT TEST COMMENTS',


### PR DESCRIPTION
We allow blank true for `test_status`.

https://github.com/umts/incidents/blob/a211f42e26ef01d10a1d5362a7fdb487e871ab4b/app/models/supervisor_report.rb#L21

So we have to `.present?` when checking for string presence.