### PR TITLE
Update to mail 2.8.0.rc1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,18 +11,15 @@ gem 'devise'
 gem 'haml-rails'
 gem 'jbuilder', '~> 2.5'
 
+# Required for net-* dependencies
+# can be removed once 2.8.0 is ofically released
+gem 'mail', '= 2.8.0.rc1'
+
 # Former default gem - dependency of prawn
 # can be removed when prawn is updated to depend on it
 gem 'matrix', '~> 0.4'
 
 gem 'mysql2'
-
-# Former default gems - Dependencies of mail
-# can be removed when mail is updated to depend on it
-gem 'net-imap'
-gem 'net-pop'
-gem 'net-smtp'
-
 gem 'nokogiri', '>= 1.8.1'
 gem 'openssl'
 gem 'paper_trail', '~> 12.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,8 +172,11 @@ GEM
     loofah (2.17.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.0.rc1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
@@ -409,11 +412,9 @@ DEPENDENCIES
   haml_lint
   jbuilder (~> 2.5)
   listen
+  mail (= 2.8.0.rc1)
   matrix (~> 0.4)
   mysql2
-  net-imap
-  net-pop
-  net-smtp
   nokogiri (>= 1.8.1)
   openssl
   paper_trail (~> 12.0)


### PR DESCRIPTION
Slowly moving to resolving the problems caused by the removal of default gems.