### PR TITLE
Update SSH gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,13 +194,13 @@ GEM
       timeout
     net-protocol (0.1.3)
       timeout
-    net-scp (3.0.0)
-      net-ssh (>= 2.6.5, < 7.0.0)
+    net-scp (4.0.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
     net-smtp (0.3.1)
       digest
       net-protocol
       timeout
-    net-ssh (6.1.0)
+    net-ssh (7.0.1)
     nio4r (2.5.8)
     nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
@@ -348,7 +348,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sshkit (1.21.2)
+    sshkit (1.21.3)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     strscan (3.0.3)


### PR DESCRIPTION
Turns out I was wrong in #357, the update to openssl _did_ break something (net-ssh).