### PR TITLE
Upgrade puma to 6.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,7 +227,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (5.0.3)
-    puma (5.6.4)
+    puma (6.3.1)
       nio4r (~> 2.0)
     racc (1.7.1)
     rack (2.2.8)


### PR DESCRIPTION
Look, Dependabot, just because I haven't merged your major version bump to Sidekiq that only fixes a vulnerability in the metrics page we don't use, doesn't mean I don't want any other updates.