### PR TITLE
Don't prefix queues with app name/environment

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,10 +59,8 @@ Rails.application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
-  # Use a real queuing backend for Active Job (and separate queues per environment).
+  # Use a real queuing backend for Active Job
   config.active_job.queue_adapter     = :sidekiq
-  config.active_job.queue_name_prefix = "incidents_production"
-  config.action_mailer.deliver_later_queue_name = 'mailers'
 
   config.action_mailer.perform_caching = false
 


### PR DESCRIPTION
The prefix ends up getting prepended to the queue names, and jobs get inserted into Redis with a queue name of e.g. `incidents_production_default`. Meanwhile, sidekiq is trundling along watching a queue named `default` and no jobs ever get processed. Turns out sidekiq has been broken in production since 2021 when we last did a Rails upgrade.

The author of Sidekiq thinks this setting [is a bad idea](https://github.com/sidekiq/sidekiq/issues/4034#issuecomment-442988685).