### PR TITLE
Upgrade Sidekiq to 6.5.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'turbolinks', '~> 5'
 
 group :production do
   gem 'exception_notification', '~> 4.4.3'
-  gem 'sidekiq', '~> 6.4.0'
+  gem 'sidekiq', '~> 6.5.12'
   gem 'terser'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.2.2)
-    connection_pool (2.2.5)
+    connection_pool (2.4.1)
     crass (1.0.6)
     csv (3.1.9)
     date (3.3.3)
@@ -266,7 +266,7 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (4.5.1)
+    redis (4.8.1)
     regexp_parser (2.8.1)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -329,10 +329,10 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     sexp_processor (4.15.2)
-    sidekiq (6.4.0)
-      connection_pool (>= 2.2.2)
+    sidekiq (6.5.12)
+      connection_pool (>= 2.2.5, < 3)
       rack (~> 2.0)
-      redis (>= 4.2.0)
+      redis (>= 4.5.0, < 5)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -420,7 +420,7 @@ DEPENDENCIES
   rubocop-rspec
   sassc-rails
   selenium-webdriver
-  sidekiq (~> 6.4.0)
+  sidekiq (~> 6.5.12)
   simplecov (~> 0.15)
   terser
   timecop (~> 0.9.1)


### PR DESCRIPTION
We should be OK to go to 7 on the production serer, but I wanted to make a stop at the most recent 6.x version first to be safe.