### PR TITLE
Fix up the production mail server settings

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -106,8 +106,10 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: 'incidents.pvta.com' }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    address: 'skylark.websitewelcome.com',
-    authentication: :plain,
+    address: 'mail.pvtaapps.com',
+    port: 465,
+    ssl: true,
+    authentication: :login,
     password: Rails.application.credentials.smtp_password,
     user_name: 'incidents@pvtaapps.com'
   }


### PR DESCRIPTION
Interestingly, mail.pvtaapps.com is _also_ skylark for mail handling purposes. But it has started waiting 5 seconds to say `HELO`, which was the "actual" problem. May as well use the recommended host, though, and using SMTP over TLS it answers immediately.