### PR TITLE
Update Sidekiq to 7.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'turbolinks', '~> 5'
 
 group :production do
   gem 'exception_notification', '~> 4.4.3'
-  gem 'sidekiq', '~> 6.5.12'
+  gem 'sidekiq', '~> 7.0'
   gem 'terser'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,7 +266,8 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (4.8.1)
+    redis-client (0.17.1)
+      connection_pool
     regexp_parser (2.8.1)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -329,10 +330,11 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     sexp_processor (4.15.2)
-    sidekiq (6.5.12)
-      connection_pool (>= 2.2.5, < 3)
-      rack (~> 2.0)
-      redis (>= 4.5.0, < 5)
+    sidekiq (7.1.6)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.14.0)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -420,7 +422,7 @@ DEPENDENCIES
   rubocop-rspec
   sassc-rails
   selenium-webdriver
-  sidekiq (~> 6.5.12)
+  sidekiq (~> 7.0)
   simplecov (~> 0.15)
   terser
   timecop (~> 0.9.1)


### PR DESCRIPTION
We only use it for sending emails, and we have sent at least one in production with no deprecation warnings. I Think this is now OK

Redis on the incidents server has already been updated to 7.2.