### PR TITLE
Update mysql2 to 0.5.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,7 @@ GEM
     mini_portile2 (2.8.4)
     minitest (5.19.0)
     msgpack (1.4.5)
-    mysql2 (0.5.3)
+    mysql2 (0.5.5)
     net-imap (0.3.7)
       date
       net-protocol


### PR DESCRIPTION
Eliminates a warning introduced in Ruby 3.2 - something about not defining or undefining `alloc` functions in C extensions?