### PR TITLE
Add bootsnap precompile step to deploy process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@
 
 .byebug_history
 
+# Ignore bootsnap cache
+/bootsnap
+
 # Ignore all of coverage, except the .last_run.json
 /coverage/index.html
 /coverage/assets/*

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,5 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+ENV['BOOTSNAP_CACHE_DIR'] ||= File.expand_path('../', __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
 require "bootsnap/setup" # Speed up boot time by caching expensive operations.

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -20,5 +20,9 @@ append :linked_dirs,
        'vendor/bundle',
        '.bundle'
 
+set :bundle_bins, fetch(:bundle_bins, []).push('bootsnap')
+
 set :sidekiq_user, 'root'
 set :sidekiq_service_unit_user, :system
+
+before 'deploy:updated', 'bootsnap:precompile'

--- a/lib/capistrano/tasks/bootsnap.rake
+++ b/lib/capistrano/tasks/bootsnap.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+namespace :bootsnap do
+  desc 'Precompile bootsnap'
+  task :precompile do
+    on roles %i[web app] do
+      within release_path do
+        execute :bootsnap, '--cache-dir', release_path, :precompile, '--gemfile', 'app/', 'lib/'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Having Bootsnap enabled in production without setting anything up to periodically clear the cache means that the cache just grows forever.