### PR TITLE
Try even harder to get Chrome to download PDFs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,7 +54,13 @@ RSpec.configure do |config|
 
   config.before :each, type: :system, js: true do
     driven_by :selenium, using: :headless_chrome do |driver_options|
-      driver_options.add_preference :download, default_directory: Downloads::PATH
+      driver_options.add_preference :download,
+        default_directory: Downloads::PATH,
+        prompt_for_download: false,
+        directory_upgrade: true
+      driver_options.add_preference :plugins,
+        always_open_pdf_externally: true,
+        plugins_disabled: ['Chrome PDF Viewer']
     end
   end
 


### PR DESCRIPTION
An alternative tack to #482, this PR makes downloads _work_ again.

It turns out that not only did we have some expectations on the files downloaded, we also were looking at the "`page`" in some cases to assert the lack of an error page and that was breaking when the page was actually the Chrome PDF viewer.